### PR TITLE
feat: 초안 API baseline 구현

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -10,6 +10,36 @@
 
 ---
 
+## 2026-03-26 (Draft API baseline)
+
+### 완료
+
+- 이슈 `#23` 기준 `apps/api` 초안 도메인 baseline 추가
+- PostgreSQL migration `0003_create_drafts.sql`로 `drafts`, `draft_entries` 테이블 및 인덱스 추가
+- `POST /drafts`, `GET /drafts`, `GET /drafts/:id`, `PATCH /drafts/:id`, `POST /drafts/:id/entries` 구현
+- 초안 목록 응답에 `entryCount`를 포함하고 상세 응답에 ordered draft entries 구조 추가
+- draft ownership, 존재하지 않는 리소스, 동일 초안 내 중복 entry 첨부 방지 로직 추가
+- Drafts 서비스 단위 테스트와 fake PostgreSQL / Redis 기반 e2e 테스트 보강
+
+### 현재 상태
+
+- 인증된 사용자는 자신의 초안을 생성, 조회, 수정하고 기록을 초안에 순서대로 담기 시작할 수 있다
+- 초안 상세 응답이 이후 프론트 draft 화면이 바로 사용할 수 있는 baseline 계약을 제공한다
+- reorder, entry 제거, preview 전용 계약은 아직 구현되지 않았고 후속 이슈 범위로 남아 있다
+
+### 다음 액션
+
+1. `apps/web` draft list / detail 화면을 실제 draft API에 연결한다
+2. draft entry reorder API와 제거 API를 추가해 초안 정리 흐름을 완성한다
+3. draft preview API와 프론트 preview 화면 연결을 시작한다
+
+### 메모
+
+- 백엔드 검증은 `pnpm --filter @book-maker/api lint`, `typecheck`, `test`, `test:e2e` 기준으로 확인한다
+- 초안 baseline 리스크는 ownership, 존재하지 않는 entry 첨부, 중복 첨부 경계를 서비스/e2e 테스트로 먼저 고정했다
+
+---
+
 ## 2026-03-25 (Archive list / detail integration)
 
 ### 완료

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { authConfig } from './config/auth.config';
 import { databaseConfig } from './config/database.config';
 import { validateEnvironment } from './config/env.validation';
 import { redisConfig } from './config/redis.config';
+import { DraftsModule } from './drafts/drafts.module';
 import { EntriesModule } from './entries/entries.module';
 import { HealthModule } from './health/health.module';
 import { InfrastructureModule } from './infrastructure/infrastructure.module';
@@ -23,6 +24,7 @@ import { UsersModule } from './users/users.module';
     UsersModule,
     AuthModule,
     EntriesModule,
+    DraftsModule,
     HealthModule,
   ],
 })

--- a/apps/api/src/drafts/draft.types.ts
+++ b/apps/api/src/drafts/draft.types.ts
@@ -1,0 +1,81 @@
+import { PublicEntry, toPublicEntry } from '../entries/entry.types';
+
+export const DRAFT_STATUSES = ['active', 'archived'] as const;
+
+export type DraftStatus = (typeof DRAFT_STATUSES)[number];
+
+export type DraftRecord = {
+  id: string;
+  userId: string;
+  title: string;
+  description: string | null;
+  status: DraftStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  entryCount: number;
+};
+
+export type DraftEntryRecord = {
+  id: string;
+  position: number;
+  createdAt: Date;
+  entry: {
+    id: string;
+    userId: string;
+    title: string | null;
+    body: string;
+    status: PublicEntry['status'];
+    createdAt: Date;
+    updatedAt: Date;
+    lastSavedAt: Date;
+  };
+};
+
+export type DraftDetailRecord = DraftRecord & {
+  entries: DraftEntryRecord[];
+};
+
+export type PublicDraft = {
+  id: string;
+  title: string;
+  description: string | null;
+  status: DraftStatus;
+  entryCount: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PublicDraftEntry = {
+  id: string;
+  position: number;
+  createdAt: string;
+  entry: PublicEntry;
+};
+
+export type PublicDraftDetail = PublicDraft & {
+  entries: PublicDraftEntry[];
+};
+
+export function toPublicDraft(draft: DraftRecord): PublicDraft {
+  return {
+    id: draft.id,
+    title: draft.title,
+    description: draft.description,
+    status: draft.status,
+    entryCount: draft.entryCount,
+    createdAt: draft.createdAt.toISOString(),
+    updatedAt: draft.updatedAt.toISOString(),
+  };
+}
+
+export function toPublicDraftDetail(draft: DraftDetailRecord): PublicDraftDetail {
+  return {
+    ...toPublicDraft(draft),
+    entries: draft.entries.map((draftEntry) => ({
+      id: draftEntry.id,
+      position: draftEntry.position,
+      createdAt: draftEntry.createdAt.toISOString(),
+      entry: toPublicEntry(draftEntry.entry),
+    })),
+  };
+}

--- a/apps/api/src/drafts/drafts.controller.ts
+++ b/apps/api/src/drafts/drafts.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { AuthGuard } from '../auth/guards/auth.guard';
+import { toPublicDraft, toPublicDraftDetail } from './draft.types';
+import { DraftsService } from './drafts.service';
+import { AddDraftEntriesDto } from './dto/add-draft-entries.dto';
+import { CreateDraftDto } from './dto/create-draft.dto';
+import { UpdateDraftDto } from './dto/update-draft.dto';
+
+@Controller('drafts')
+@UseGuards(AuthGuard)
+export class DraftsController {
+  constructor(private readonly draftsService: DraftsService) {}
+
+  @Post()
+  async createDraft(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: CreateDraftDto,
+  ) {
+    const draft = await this.draftsService.createDraft(user.userId, dto);
+
+    return toPublicDraft(draft);
+  }
+
+  @Get()
+  async listDrafts(@CurrentUser() user: AuthenticatedUser) {
+    const drafts = await this.draftsService.listDrafts(user.userId);
+
+    return drafts.map(toPublicDraft);
+  }
+
+  @Get(':draftId')
+  async getDraft(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('draftId') draftId: string,
+  ) {
+    const draft = await this.draftsService.findDraftById(user.userId, draftId);
+
+    return toPublicDraftDetail(draft);
+  }
+
+  @Patch(':draftId')
+  async updateDraft(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('draftId') draftId: string,
+    @Body() dto: UpdateDraftDto,
+  ) {
+    const draft = await this.draftsService.updateDraft(user.userId, draftId, dto);
+
+    return toPublicDraft(draft);
+  }
+
+  @Post(':draftId/entries')
+  async addEntriesToDraft(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('draftId') draftId: string,
+    @Body() dto: AddDraftEntriesDto,
+  ) {
+    const draft = await this.draftsService.addEntriesToDraft(
+      user.userId,
+      draftId,
+      dto.entryIds,
+    );
+
+    return toPublicDraftDetail(draft);
+  }
+}

--- a/apps/api/src/drafts/drafts.module.ts
+++ b/apps/api/src/drafts/drafts.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '../auth/auth.module';
+import { InfrastructureModule } from '../infrastructure/infrastructure.module';
+import { DraftsController } from './drafts.controller';
+import { DraftsService } from './drafts.service';
+
+@Module({
+  imports: [InfrastructureModule, AuthModule],
+  controllers: [DraftsController],
+  providers: [DraftsService],
+  exports: [DraftsService],
+})
+export class DraftsModule {}

--- a/apps/api/src/drafts/drafts.service.spec.ts
+++ b/apps/api/src/drafts/drafts.service.spec.ts
@@ -1,0 +1,79 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { DatabaseService } from '../infrastructure/database/database.service';
+import { DraftsService } from './drafts.service';
+
+describe('DraftsService', () => {
+  let query: jest.Mock;
+  let draftsService: DraftsService;
+
+  beforeEach(() => {
+    query = jest.fn();
+
+    const databaseService = {
+      getPool: () => ({
+        query,
+      }),
+    } as unknown as DatabaseService;
+
+    draftsService = new DraftsService(databaseService);
+  });
+
+  it('rejects a blank draft title on creation', async () => {
+    await expect(
+      draftsService.createDraft('user-1', {
+        title: '   ',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects empty update payloads', async () => {
+    await expect(draftsService.updateDraft('user-1', 'draft-1', {})).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('throws when updating a draft outside the current user scope', async () => {
+    query.mockResolvedValue({
+      rows: [],
+    });
+
+    await expect(
+      draftsService.updateDraft('user-1', 'draft-1', {
+        title: '바다 초안',
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('throws when adding duplicate entries to the same draft', async () => {
+    query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-1',
+            userId: 'user-1',
+            title: '초안',
+            description: null,
+            status: 'active',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            entryCount: 1,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: 'entry-1' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ entryId: 'entry-1' }],
+      });
+
+    await expect(
+      draftsService.addEntriesToDraft('user-1', 'draft-1', ['entry-1']),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+});

--- a/apps/api/src/drafts/drafts.service.ts
+++ b/apps/api/src/drafts/drafts.service.ts
@@ -1,0 +1,373 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { EntryStatus } from '../entries/entry.types';
+import { DatabaseService } from '../infrastructure/database/database.service';
+import {
+  DraftDetailRecord,
+  DraftEntryRecord,
+  DraftRecord,
+  DraftStatus,
+} from './draft.types';
+
+type DraftRow = {
+  id: string;
+  userId: string;
+  title: string;
+  description: string | null;
+  status: DraftStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  entryCount: number | string;
+};
+
+type DraftEntryRow = {
+  id: string;
+  position: number;
+  createdAt: Date;
+  entryId: string;
+  entryUserId: string;
+  entryTitle: string | null;
+  entryBody: string;
+  entryStatus: EntryStatus;
+  entryCreatedAt: Date;
+  entryUpdatedAt: Date;
+  entryLastSavedAt: Date;
+};
+
+type ExistingDraftEntryRow = {
+  entryId: string;
+};
+
+type ExistingEntryRow = {
+  id: string;
+};
+
+type MaxPositionRow = {
+  maxPosition: number | string | null;
+};
+
+type CreateDraftInput = {
+  title: string;
+  description?: string;
+  status?: DraftStatus;
+};
+
+type UpdateDraftInput = {
+  title?: string;
+  description?: string;
+  status?: DraftStatus;
+};
+
+@Injectable()
+export class DraftsService {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async createDraft(userId: string, input: CreateDraftInput): Promise<DraftRecord> {
+    const title = normalizeRequiredTitle(input.title);
+    const description = normalizeOptionalText(input.description);
+    const result = await this.databaseService.getPool().query<DraftRow>(
+      `
+        INSERT INTO drafts (user_id, title, description, status)
+        VALUES ($1, $2, $3, $4)
+        RETURNING
+          id,
+          user_id AS "userId",
+          title,
+          description,
+          status,
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+      `,
+      [userId, title, description, input.status ?? 'active'],
+    );
+
+    return {
+      ...toDraftRecord(result.rows[0]),
+      entryCount: 0,
+    };
+  }
+
+  async listDrafts(userId: string): Promise<DraftRecord[]> {
+    const result = await this.databaseService.getPool().query<DraftRow>(
+      `
+        SELECT
+          d.id,
+          d.user_id AS "userId",
+          d.title,
+          d.description,
+          d.status,
+          d.created_at AS "createdAt",
+          d.updated_at AS "updatedAt",
+          COUNT(de.id)::int AS "entryCount"
+        FROM drafts d
+        LEFT JOIN draft_entries de ON de.draft_id = d.id
+        WHERE d.user_id = $1
+        GROUP BY d.id
+        ORDER BY d.updated_at DESC, d.created_at DESC
+      `,
+      [userId],
+    );
+
+    return result.rows.map(toDraftRecord);
+  }
+
+  async findDraftById(userId: string, draftId: string): Promise<DraftDetailRecord> {
+    const draft = await this.findDraftRecordById(userId, draftId);
+    const entries = await this.listDraftEntries(draftId);
+
+    return {
+      ...draft,
+      entries,
+    };
+  }
+
+  async updateDraft(
+    userId: string,
+    draftId: string,
+    input: UpdateDraftInput,
+  ): Promise<DraftRecord> {
+    if (
+      input.title === undefined &&
+      input.description === undefined &&
+      input.status === undefined
+    ) {
+      throw new BadRequestException('수정할 초안 필드가 필요합니다.');
+    }
+
+    const result = await this.databaseService.getPool().query<DraftRow>(
+      `
+        UPDATE drafts
+        SET
+          title = CASE WHEN $3 THEN $4 ELSE title END,
+          description = CASE WHEN $5 THEN $6 ELSE description END,
+          status = CASE WHEN $7 THEN $8 ELSE status END,
+          updated_at = NOW()
+        WHERE id = $1 AND user_id = $2
+        RETURNING
+          id,
+          user_id AS "userId",
+          title,
+          description,
+          status,
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+      `,
+      [
+        draftId,
+        userId,
+        input.title !== undefined,
+        input.title !== undefined ? normalizeRequiredTitle(input.title) : null,
+        input.description !== undefined,
+        normalizeOptionalText(input.description),
+        input.status !== undefined,
+        input.status ?? null,
+      ],
+    );
+
+    const draft = result.rows[0];
+
+    if (!draft) {
+      throw new NotFoundException('초안을 찾을 수 없습니다.');
+    }
+
+    return {
+      ...toDraftRecord(draft),
+      entryCount: await this.countDraftEntries(draftId),
+    };
+  }
+
+  async addEntriesToDraft(
+    userId: string,
+    draftId: string,
+    entryIds: string[],
+  ): Promise<DraftDetailRecord> {
+    if (entryIds.length === 0) {
+      throw new BadRequestException('초안에 담을 기록이 필요합니다.');
+    }
+
+    await this.findDraftRecordById(userId, draftId);
+
+    const existingEntriesResult =
+      await this.databaseService.getPool().query<ExistingEntryRow>(
+        `
+          SELECT id
+          FROM entries
+          WHERE user_id = $1 AND id = ANY($2::uuid[])
+        `,
+        [userId, entryIds],
+      );
+
+    if (existingEntriesResult.rows.length !== entryIds.length) {
+      throw new NotFoundException('기록을 찾을 수 없습니다.');
+    }
+
+    const duplicatedEntriesResult =
+      await this.databaseService.getPool().query<ExistingDraftEntryRow>(
+        `
+          SELECT entry_id AS "entryId"
+          FROM draft_entries
+          WHERE draft_id = $1 AND entry_id = ANY($2::uuid[])
+        `,
+        [draftId, entryIds],
+      );
+
+    if (duplicatedEntriesResult.rows.length > 0) {
+      throw new ConflictException('이미 초안에 담긴 기록입니다.');
+    }
+
+    const maxPositionResult = await this.databaseService.getPool().query<MaxPositionRow>(
+      `
+        SELECT COALESCE(MAX(position), 0) AS "maxPosition"
+        FROM draft_entries
+        WHERE draft_id = $1
+      `,
+      [draftId],
+    );
+
+    let position = Number(maxPositionResult.rows[0]?.maxPosition ?? 0);
+
+    for (const entryId of entryIds) {
+      position += 1;
+
+      await this.databaseService.getPool().query(
+        `
+          INSERT INTO draft_entries (draft_id, entry_id, position)
+          VALUES ($1, $2, $3)
+        `,
+        [draftId, entryId, position],
+      );
+    }
+
+    await this.databaseService.getPool().query(
+      `
+        UPDATE drafts
+        SET updated_at = NOW()
+        WHERE id = $1 AND user_id = $2
+      `,
+      [draftId, userId],
+    );
+
+    return this.findDraftById(userId, draftId);
+  }
+
+  private async findDraftRecordById(userId: string, draftId: string): Promise<DraftRecord> {
+    const result = await this.databaseService.getPool().query<DraftRow>(
+      `
+        SELECT
+          d.id,
+          d.user_id AS "userId",
+          d.title,
+          d.description,
+          d.status,
+          d.created_at AS "createdAt",
+          d.updated_at AS "updatedAt",
+          COUNT(de.id)::int AS "entryCount"
+        FROM drafts d
+        LEFT JOIN draft_entries de ON de.draft_id = d.id
+        WHERE d.id = $1 AND d.user_id = $2
+        GROUP BY d.id
+        LIMIT 1
+      `,
+      [draftId, userId],
+    );
+
+    const draft = result.rows[0];
+
+    if (!draft) {
+      throw new NotFoundException('초안을 찾을 수 없습니다.');
+    }
+
+    return toDraftRecord(draft);
+  }
+
+  private async listDraftEntries(draftId: string): Promise<DraftEntryRecord[]> {
+    const result = await this.databaseService.getPool().query<DraftEntryRow>(
+      `
+        SELECT
+          de.id,
+          de.position,
+          de.created_at AS "createdAt",
+          e.id AS "entryId",
+          e.user_id AS "entryUserId",
+          e.title AS "entryTitle",
+          e.body AS "entryBody",
+          e.status AS "entryStatus",
+          e.created_at AS "entryCreatedAt",
+          e.updated_at AS "entryUpdatedAt",
+          e.last_saved_at AS "entryLastSavedAt"
+        FROM draft_entries de
+        INNER JOIN entries e ON e.id = de.entry_id
+        WHERE de.draft_id = $1
+        ORDER BY de.position ASC, de.created_at ASC
+      `,
+      [draftId],
+    );
+
+    return result.rows.map((row) => ({
+      id: row.id,
+      position: row.position,
+      createdAt: row.createdAt,
+      entry: {
+        id: row.entryId,
+        userId: row.entryUserId,
+        title: row.entryTitle,
+        body: row.entryBody,
+        status: row.entryStatus,
+        createdAt: row.entryCreatedAt,
+        updatedAt: row.entryUpdatedAt,
+        lastSavedAt: row.entryLastSavedAt,
+      },
+    }));
+  }
+
+  private async countDraftEntries(draftId: string): Promise<number> {
+    const result = await this.databaseService.getPool().query<MaxPositionRow>(
+      `
+        SELECT COUNT(*)::int AS "maxPosition"
+        FROM draft_entries
+        WHERE draft_id = $1
+      `,
+      [draftId],
+    );
+
+    return Number(result.rows[0]?.maxPosition ?? 0);
+  }
+}
+
+function toDraftRecord(row: DraftRow): DraftRecord {
+  return {
+    id: row.id,
+    userId: row.userId,
+    title: row.title,
+    description: row.description,
+    status: row.status,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    entryCount: Number(row.entryCount ?? 0),
+  };
+}
+
+function normalizeRequiredTitle(title: string): string {
+  const normalized = title.trim();
+
+  if (normalized.length === 0) {
+    throw new BadRequestException('초안 제목은 비워둘 수 없습니다.');
+  }
+
+  return normalized;
+}
+
+function normalizeOptionalText(value: string | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  const normalized = value.trim();
+
+  return normalized.length > 0 ? normalized : null;
+}

--- a/apps/api/src/drafts/dto/add-draft-entries.dto.ts
+++ b/apps/api/src/drafts/dto/add-draft-entries.dto.ts
@@ -1,0 +1,9 @@
+import { ArrayNotEmpty, ArrayUnique, IsArray, IsUUID } from 'class-validator';
+
+export class AddDraftEntriesDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @IsUUID('4', { each: true })
+  entryIds!: string[];
+}

--- a/apps/api/src/drafts/dto/create-draft.dto.ts
+++ b/apps/api/src/drafts/dto/create-draft.dto.ts
@@ -1,0 +1,19 @@
+import { IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+
+import type { DraftStatus } from '../draft.types';
+import { DRAFT_STATUSES } from '../draft.types';
+
+export class CreateDraftDto {
+  @IsString()
+  @MaxLength(255)
+  title!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  description?: string;
+
+  @IsOptional()
+  @IsIn(DRAFT_STATUSES)
+  status?: DraftStatus;
+}

--- a/apps/api/src/drafts/dto/update-draft.dto.ts
+++ b/apps/api/src/drafts/dto/update-draft.dto.ts
@@ -1,0 +1,20 @@
+import { IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+
+import type { DraftStatus } from '../draft.types';
+import { DRAFT_STATUSES } from '../draft.types';
+
+export class UpdateDraftDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  description?: string;
+
+  @IsOptional()
+  @IsIn(DRAFT_STATUSES)
+  status?: DraftStatus;
+}

--- a/apps/api/src/infrastructure/database/migrations/0003_create_drafts.sql
+++ b/apps/api/src/infrastructure/database/migrations/0003_create_drafts.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS drafts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title VARCHAR(255) NOT NULL,
+  description TEXT,
+  status VARCHAR(32) NOT NULL DEFAULT 'active',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_drafts_user_updated_at
+  ON drafts (user_id, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_drafts_user_created_at
+  ON drafts (user_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS draft_entries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  draft_id UUID NOT NULL REFERENCES drafts(id) ON DELETE CASCADE,
+  entry_id UUID NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
+  position INTEGER NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (draft_id, entry_id),
+  UNIQUE (draft_id, position)
+);
+
+CREATE INDEX IF NOT EXISTS idx_draft_entries_draft_position
+  ON draft_entries (draft_id, position ASC);
+
+CREATE INDEX IF NOT EXISTS idx_draft_entries_entry_id
+  ON draft_entries (entry_id);

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -12,6 +12,7 @@ import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import request from 'supertest';
 
 import { AppModule } from './../src/app.module';
+import { DraftStatus } from './../src/drafts/draft.types';
 import { EntryStatus } from './../src/entries/entry.types';
 import { DatabaseService } from './../src/infrastructure/database/database.service';
 import { RedisService } from './../src/infrastructure/redis/redis.service';
@@ -85,6 +86,43 @@ type EntryResponseBody = {
   lastSavedAt: string;
 };
 
+type DraftResponseBody = {
+  id: string;
+  title: string;
+  description: string | null;
+  status: DraftStatus;
+  entryCount: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type DraftDetailResponseBody = DraftResponseBody & {
+  entries: Array<{
+    id: string;
+    position: number;
+    createdAt: string;
+    entry: EntryResponseBody;
+  }>;
+};
+
+type StoredDraft = {
+  id: string;
+  userId: string;
+  title: string;
+  description: string | null;
+  status: DraftStatus;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type StoredDraftEntry = {
+  id: string;
+  draftId: string;
+  entryId: string;
+  position: number;
+  createdAt: Date;
+};
+
 class DuplicateEmailError extends Error {
   code = '23505' as const;
 
@@ -97,6 +135,8 @@ class FakePool {
   private readonly usersById = new Map<string, StoredUser>();
   private readonly usersByEmail = new Map<string, StoredUser>();
   private readonly entriesById = new Map<string, StoredEntry>();
+  private readonly draftsById = new Map<string, StoredDraft>();
+  private readonly draftEntriesById = new Map<string, StoredDraftEntry>();
 
   query<T>(queryText: string, values: unknown[]) {
     const normalizedQuery = queryText.replace(/\s+/g, ' ').trim();
@@ -117,10 +157,61 @@ class FakePool {
       return this.insertEntry<T>(values);
     }
 
+    if (normalizedQuery.startsWith('INSERT INTO drafts')) {
+      return this.insertDraft<T>(values);
+    }
+
+    if (normalizedQuery.startsWith('INSERT INTO draft_entries')) {
+      return this.insertDraftEntry(values);
+    }
+
     if (
       normalizedQuery.includes('FROM entries WHERE user_id = $1 ORDER BY updated_at DESC')
     ) {
       return this.listEntries<T>(values);
+    }
+
+    if (
+      normalizedQuery.includes('FROM drafts d LEFT JOIN draft_entries de ON de.draft_id = d.id') &&
+      normalizedQuery.includes('WHERE d.user_id = $1') &&
+      normalizedQuery.includes('ORDER BY d.updated_at DESC')
+    ) {
+      return this.listDrafts<T>(values);
+    }
+
+    if (
+      normalizedQuery.includes('FROM drafts d LEFT JOIN draft_entries de ON de.draft_id = d.id') &&
+      normalizedQuery.includes('WHERE d.id = $1 AND d.user_id = $2')
+    ) {
+      return this.selectDraftById<T>(values);
+    }
+
+    if (
+      normalizedQuery.includes('FROM draft_entries de INNER JOIN entries e ON e.id = de.entry_id')
+    ) {
+      return this.listDraftEntries<T>(values);
+    }
+
+    if (
+      normalizedQuery.includes('FROM entries WHERE user_id = $1 AND id = ANY($2::uuid[])')
+    ) {
+      return this.selectEntriesByIds<T>(values);
+    }
+
+    if (
+      normalizedQuery.includes(
+        'FROM draft_entries WHERE draft_id = $1 AND entry_id = ANY($2::uuid[])',
+      )
+    ) {
+      return this.selectDraftEntriesByEntryIds<T>(values);
+    }
+
+    if (normalizedQuery.includes('SELECT COALESCE(MAX(position), 0) AS "maxPosition"')) {
+      return this.selectDraftMaxPosition<T>(values);
+    }
+
+    if (normalizedQuery.includes('SELECT COUNT(*)::int AS "maxPosition"')) {
+      return this.countDraftEntries<T>(values);
     }
 
     if (normalizedQuery.startsWith('DELETE FROM entries')) {
@@ -133,6 +224,20 @@ class FakePool {
 
     if (normalizedQuery.startsWith('UPDATE entries')) {
       return this.updateEntry<T>(values);
+    }
+
+    if (
+      normalizedQuery.startsWith('UPDATE drafts') &&
+      normalizedQuery.includes('RETURNING')
+    ) {
+      return this.updateDraft<T>(values);
+    }
+
+    if (
+      normalizedQuery.startsWith('UPDATE drafts') &&
+      !normalizedQuery.includes('RETURNING')
+    ) {
+      return this.touchDraft(values);
     }
 
     return Promise.reject(new Error(`Unsupported fake query: ${normalizedQuery}`));
@@ -200,6 +305,45 @@ class FakePool {
     });
   }
 
+  private insertDraft<T>(values: unknown[]) {
+    const now = new Date();
+    const draft: StoredDraft = {
+      id: randomUUID(),
+      userId: values[0] as string,
+      title: values[1] as string,
+      description: (values[2] as string | null) ?? null,
+      status: values[3] as DraftStatus,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.draftsById.set(draft.id, draft);
+
+    return Promise.resolve({
+      rows: [this.toDraftRow(draft, 0)] as T[],
+    });
+  }
+
+  private insertDraftEntry(values: unknown[]) {
+    const draftId = values[0] as string;
+    const entryId = values[1] as string;
+    const position = values[2] as number;
+    const draftEntry: StoredDraftEntry = {
+      id: randomUUID(),
+      draftId,
+      entryId,
+      position,
+      createdAt: new Date(),
+    };
+
+    this.draftEntriesById.set(draftEntry.id, draftEntry);
+
+    return Promise.resolve({
+      rowCount: 1,
+      rows: [],
+    });
+  }
+
   private listEntries<T>(values: unknown[]) {
     const userId = values[0] as string;
     const entries = [...this.entriesById.values()]
@@ -209,6 +353,34 @@ class FakePool {
 
     return Promise.resolve({
       rows: entries,
+    });
+  }
+
+  private listDrafts<T>(values: unknown[]) {
+    const userId = values[0] as string;
+    const drafts = [...this.draftsById.values()]
+      .filter((draft) => draft.userId === userId)
+      .sort((left, right) => right.updatedAt.getTime() - left.updatedAt.getTime())
+      .map((draft) => this.toDraftRow(draft, this.getDraftEntryCount(draft.id))) as T[];
+
+    return Promise.resolve({
+      rows: drafts,
+    });
+  }
+
+  private selectDraftById<T>(values: unknown[]) {
+    const draftId = values[0] as string;
+    const userId = values[1] as string;
+    const draft = this.draftsById.get(draftId);
+
+    if (!draft || draft.userId !== userId) {
+      return Promise.resolve({
+        rows: [] as T[],
+      });
+    }
+
+    return Promise.resolve({
+      rows: [this.toDraftRow(draft, this.getDraftEntryCount(draft.id))] as T[],
     });
   }
 
@@ -225,6 +397,82 @@ class FakePool {
 
     return Promise.resolve({
       rows: [this.toEntryRow(entry)] as T[],
+    });
+  }
+
+  private listDraftEntries<T>(values: unknown[]) {
+    const draftId = values[0] as string;
+    const rows = [...this.draftEntriesById.values()]
+      .filter((draftEntry) => draftEntry.draftId === draftId)
+      .sort((left, right) => left.position - right.position)
+      .map((draftEntry) => {
+        const entry = this.entriesById.get(draftEntry.entryId);
+
+        if (!entry) {
+          throw new Error(`Missing entry for draft entry ${draftEntry.id}`);
+        }
+
+        return {
+          id: draftEntry.id,
+          position: draftEntry.position,
+          createdAt: draftEntry.createdAt,
+          entryId: entry.id,
+          entryUserId: entry.userId,
+          entryTitle: entry.title,
+          entryBody: entry.body,
+          entryStatus: entry.status,
+          entryCreatedAt: entry.createdAt,
+          entryUpdatedAt: entry.updatedAt,
+          entryLastSavedAt: entry.lastSavedAt,
+        };
+      }) as T[];
+
+    return Promise.resolve({
+      rows,
+    });
+  }
+
+  private selectEntriesByIds<T>(values: unknown[]) {
+    const userId = values[0] as string;
+    const entryIds = values[1] as string[];
+    const rows = entryIds
+      .map((entryId) => this.entriesById.get(entryId))
+      .filter((entry): entry is StoredEntry => Boolean(entry && entry.userId === userId))
+      .map((entry) => ({ id: entry.id })) as T[];
+
+    return Promise.resolve({
+      rows,
+    });
+  }
+
+  private selectDraftEntriesByEntryIds<T>(values: unknown[]) {
+    const draftId = values[0] as string;
+    const entryIds = new Set(values[1] as string[]);
+    const rows = [...this.draftEntriesById.values()]
+      .filter((draftEntry) => draftEntry.draftId === draftId && entryIds.has(draftEntry.entryId))
+      .map((draftEntry) => ({ entryId: draftEntry.entryId })) as T[];
+
+    return Promise.resolve({
+      rows,
+    });
+  }
+
+  private selectDraftMaxPosition<T>(values: unknown[]) {
+    const draftId = values[0] as string;
+    const maxPosition = [...this.draftEntriesById.values()]
+      .filter((draftEntry) => draftEntry.draftId === draftId)
+      .reduce((currentMax, draftEntry) => Math.max(currentMax, draftEntry.position), 0);
+
+    return Promise.resolve({
+      rows: [{ maxPosition }] as T[],
+    });
+  }
+
+  private countDraftEntries<T>(values: unknown[]) {
+    const draftId = values[0] as string;
+
+    return Promise.resolve({
+      rows: [{ maxPosition: this.getDraftEntryCount(draftId) }] as T[],
     });
   }
 
@@ -263,6 +511,60 @@ class FakePool {
 
     return Promise.resolve({
       rows: [this.toEntryRow(entry)] as T[],
+    });
+  }
+
+  private updateDraft<T>(values: unknown[]) {
+    const draftId = values[0] as string;
+    const userId = values[1] as string;
+    const updateTitle = values[2] as boolean;
+    const title = values[3] as string | null;
+    const updateDescription = values[4] as boolean;
+    const description = values[5] as string | null;
+    const updateStatus = values[6] as boolean;
+    const status = values[7] as DraftStatus | null;
+    const draft = this.draftsById.get(draftId);
+
+    if (!draft || draft.userId !== userId) {
+      return Promise.resolve({
+        rows: [] as T[],
+      });
+    }
+
+    if (updateTitle && title !== null) {
+      draft.title = title;
+    }
+
+    if (updateDescription) {
+      draft.description = description;
+    }
+
+    if (updateStatus && status !== null) {
+      draft.status = status;
+    }
+
+    draft.updatedAt = new Date();
+
+    return Promise.resolve({
+      rows: [this.toDraftRow(draft, this.getDraftEntryCount(draft.id))] as T[],
+    });
+  }
+
+  private touchDraft(values: unknown[]) {
+    const draftId = values[0] as string;
+    const userId = values[1] as string;
+    const draft = this.draftsById.get(draftId);
+
+    if (!draft || draft.userId !== userId) {
+      return Promise.resolve({
+        rowCount: 0,
+      });
+    }
+
+    draft.updatedAt = new Date();
+
+    return Promise.resolve({
+      rowCount: 1,
     });
   }
 
@@ -306,6 +608,25 @@ class FakePool {
       updatedAt: entry.updatedAt,
       lastSavedAt: entry.lastSavedAt,
     };
+  }
+
+  private toDraftRow(draft: StoredDraft, entryCount: number) {
+    return {
+      id: draft.id,
+      userId: draft.userId,
+      title: draft.title,
+      description: draft.description,
+      status: draft.status,
+      createdAt: draft.createdAt,
+      updatedAt: draft.updatedAt,
+      entryCount,
+    };
+  }
+
+  private getDraftEntryCount(draftId: string) {
+    return [...this.draftEntriesById.values()].filter(
+      (draftEntry) => draftEntry.draftId === draftId,
+    ).length;
   }
 }
 
@@ -620,6 +941,141 @@ describe('AppController (e2e)', () => {
       .set('Authorization', `Bearer ${stranger.accessToken}`)
       .expect(404);
   });
+
+  it('creates, lists, reads, updates, and adds entries to a draft inside the current user scope', async () => {
+    const server = app.getHttpServer();
+    const auth = await signup(server, 'draft-owner@example.com');
+
+    const firstEntry = await createEntry(server, auth.accessToken, {
+      title: '첫 기록',
+      body: '첫 문장',
+    });
+    const secondEntry = await createEntry(server, auth.accessToken, {
+      title: '둘째 기록',
+      body: '둘째 문장',
+    });
+
+    const createDraftResponse = await request(server)
+      .post('/api/drafts')
+      .set('Authorization', `Bearer ${auth.accessToken}`)
+      .send({
+        title: '  파도 초안  ',
+        description: '  바다를 모은다  ',
+      })
+      .expect(201);
+    const createdDraft = createDraftResponse.body as DraftResponseBody;
+
+    expect(createdDraft.title).toBe('파도 초안');
+    expect(createdDraft.description).toBe('바다를 모은다');
+    expect(createdDraft.entryCount).toBe(0);
+    expect(createdDraft.status).toBe('active');
+
+    const listResponse = await request(server)
+      .get('/api/drafts')
+      .set('Authorization', `Bearer ${auth.accessToken}`)
+      .expect(200);
+    const listBody = listResponse.body as DraftResponseBody[];
+
+    expect(listBody).toHaveLength(1);
+    expect(listBody[0].id).toBe(createdDraft.id);
+
+    const updateResponse = await request(server)
+      .patch(`/api/drafts/${createdDraft.id}`)
+      .set('Authorization', `Bearer ${auth.accessToken}`)
+      .send({
+        title: '고요한 파도',
+        description: '',
+        status: 'archived',
+      })
+      .expect(200);
+    const updatedDraft = updateResponse.body as DraftResponseBody;
+
+    expect(updatedDraft.title).toBe('고요한 파도');
+    expect(updatedDraft.description).toBeNull();
+    expect(updatedDraft.status).toBe('archived');
+
+    const attachResponse = await request(server)
+      .post(`/api/drafts/${createdDraft.id}/entries`)
+      .set('Authorization', `Bearer ${auth.accessToken}`)
+      .send({
+        entryIds: [firstEntry.id, secondEntry.id],
+      })
+      .expect(201);
+    const attachedDraft = attachResponse.body as DraftDetailResponseBody;
+
+    expect(attachedDraft.entryCount).toBe(2);
+    expect(attachedDraft.entries).toHaveLength(2);
+    expect(attachedDraft.entries[0].position).toBe(1);
+    expect(attachedDraft.entries[0].entry.id).toBe(firstEntry.id);
+    expect(attachedDraft.entries[1].position).toBe(2);
+    expect(attachedDraft.entries[1].entry.id).toBe(secondEntry.id);
+
+    await request(server)
+      .get(`/api/drafts/${createdDraft.id}`)
+      .set('Authorization', `Bearer ${auth.accessToken}`)
+      .expect(200)
+      .expect(attachedDraft);
+
+    await request(server)
+      .post(`/api/drafts/${createdDraft.id}/entries`)
+      .set('Authorization', `Bearer ${auth.accessToken}`)
+      .send({
+        entryIds: [firstEntry.id],
+      })
+      .expect(409);
+  });
+
+  it('blocks access to another user draft and attached entries', async () => {
+    const server = app.getHttpServer();
+    const owner = await signup(server, 'draft-owner-2@example.com');
+    const stranger = await signup(server, 'draft-other@example.com');
+
+    const ownerEntry = await createEntry(server, owner.accessToken, {
+      body: 'owner entry',
+    });
+
+    const createDraftResponse = await request(server)
+      .post('/api/drafts')
+      .set('Authorization', `Bearer ${owner.accessToken}`)
+      .send({
+        title: 'owner draft',
+      })
+      .expect(201);
+    const ownerDraft = createDraftResponse.body as DraftResponseBody;
+
+    await request(server)
+      .get(`/api/drafts/${ownerDraft.id}`)
+      .set('Authorization', `Bearer ${stranger.accessToken}`)
+      .expect(404);
+
+    await request(server)
+      .patch(`/api/drafts/${ownerDraft.id}`)
+      .set('Authorization', `Bearer ${stranger.accessToken}`)
+      .send({
+        title: 'stolen',
+      })
+      .expect(404);
+
+    await request(server)
+      .post(`/api/drafts/${ownerDraft.id}/entries`)
+      .set('Authorization', `Bearer ${stranger.accessToken}`)
+      .send({
+        entryIds: [ownerEntry.id],
+      })
+      .expect(404);
+
+    const strangerEntry = await createEntry(server, stranger.accessToken, {
+      body: 'stranger entry',
+    });
+
+    await request(server)
+      .post(`/api/drafts/${ownerDraft.id}/entries`)
+      .set('Authorization', `Bearer ${owner.accessToken}`)
+      .send({
+        entryIds: [strangerEntry.id],
+      })
+      .expect(404);
+  });
 });
 
 async function signup(server: ReturnType<INestApplication['getHttpServer']>, email: string) {
@@ -633,4 +1089,21 @@ async function signup(server: ReturnType<INestApplication['getHttpServer']>, ema
     .expect(201);
 
   return response.body as AuthResponseBody;
+}
+
+async function createEntry(
+  server: ReturnType<INestApplication['getHttpServer']>,
+  accessToken: string,
+  payload: {
+    title?: string;
+    body: string;
+  },
+) {
+  const response = await request(server)
+    .post('/api/entries')
+    .set('Authorization', `Bearer ${accessToken}`)
+    .send(payload)
+    .expect(201);
+
+  return response.body as EntryResponseBody;
 }


### PR DESCRIPTION
## 요약

Phase 5 Draft Flow 진입을 위해 `apps/api`에 초안 도메인 baseline을 추가했습니다. 초안 생성, 목록, 상세, 수정과 entry 추가 계약을 마련하고 ownership 및 기본 무결성 규칙을 테스트로 고정해 이후 draft UI와 preview 작업이 의존할 backend 기준을 세웠습니다.

## 변경 내용

- PostgreSQL migration `0003_create_drafts.sql`로 `drafts`, `draft_entries` 테이블과 인덱스 추가
- `drafts` 모듈, DTO, 타입, 서비스, 컨트롤러를 추가해 `POST /drafts`, `GET /drafts`, `GET /drafts/:id`, `PATCH /drafts/:id`, `POST /drafts/:id/entries` 구현
- 초안 목록 응답에 `entryCount`, 상세 응답에 ordered draft entries 구조를 포함하도록 응답 계약 정리
- 타 사용자 draft/entry 접근, 존재하지 않는 리소스, 동일 초안 내 중복 entry 첨부를 막는 ownership 및 무결성 검증 추가
- Drafts 서비스 단위 테스트와 fake PostgreSQL / Redis 기반 e2e 테스트 확장
- `WORKLOG.md`에 이번 작업 상태와 다음 액션 반영

## 왜 이 변경이 필요한가

구현 단계 문서 기준으로 archive 다음은 draft flow이며, MVP 핵심 루프도 기록을 초안으로 묶는 경험을 다음 가치로 둡니다. 프론트 draft 화면과 preview 흐름이 의존할 backend 기준이 먼저 있어야 이후 UI 연결과 reorder/preview 후속 작업을 안전하게 진행할 수 있습니다.

## 확인 방법

- `pnpm --filter @book-maker/api lint`
- `pnpm --filter @book-maker/api typecheck`
- `pnpm --filter @book-maker/api test`
- `pnpm --filter @book-maker/api test:e2e`
- `pnpm --filter @book-maker/api build`

## 관련 문서 / 이슈

- Closes: #23
- Related: #17, #21
- Docs: `WORKLOG.md`

## 체크리스트

- [x] 현재 MVP 방향과 충돌하지 않는다
- [x] 기존 문서/구조와 정합성을 확인했다
- [x] 필요한 경우 문서를 함께 수정했다
- [x] 필요한 경우 테스트를 추가했거나 테스트 불필요 사유를 판단했다
- [x] lint / typecheck / test / build 영향을 확인했다

## 비고

- draft reorder, entry 제거, preview 전용 계약은 이번 PR 범위에서 제외했고 후속 이슈로 분리합니다.
- e2e는 기존 fake PostgreSQL / Redis provider 패턴을 따라 draft 계약과 ownership 경계를 검증했습니다.