### PR TITLE
feat: 초안 순서 변경 흐름 구현

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -10,6 +10,34 @@
 
 ---
 
+## 2026-03-26 (Draft reorder flow)
+
+### 완료
+
+- 이슈 `#27` 기준 `apps/api`에 `PATCH /drafts/:id/entries/reorder` 계약과 순서 재정렬 로직 추가
+- 초안 상세 화면에서 위/아래 이동 버튼으로 기록 순서를 바꾸는 reorder UI 연결
+- `useDrafts`에 reorder mutation 상태와 오류 메시지를 추가하고 초안 detail/list 동기화 유지
+- Drafts 서비스 테스트, fake PostgreSQL/Redis e2e, 프론트 composable 테스트에 reorder 시나리오 보강
+
+### 현재 상태
+
+- 사용자는 초안 상세 화면에서 담아둔 기록의 순서를 실제로 바꿀 수 있다
+- draft organization MVP 범위 중 reorder가 API와 프론트 양쪽에서 연결되었다
+- entry 제거와 preview 전용 API/UI는 아직 후속 범위로 남아 있다
+
+### 다음 액션
+
+1. entry 제거 흐름을 추가해 초안 정리 baseline을 완성한다
+2. draft preview API와 실제 preview 화면 연결을 시작한다
+3. draft detail에서 reorder와 remove를 함께 다루는 정리 UX를 다듬는다
+
+### 메모
+
+- reorder는 초안에 담긴 전체 entry id 집합을 그대로 보내는 계약으로 구현해 순서 무결성을 우선 보호했다
+- 검증은 `apps/api`, `apps/web`의 lint/typecheck/test/build 중심으로 확인한다
+
+---
+
 ## 2026-03-26 (Draft web integration)
 
 ### 완료

--- a/apps/api/src/drafts/drafts.controller.ts
+++ b/apps/api/src/drafts/drafts.controller.ts
@@ -15,6 +15,7 @@ import { toPublicDraft, toPublicDraftDetail } from './draft.types';
 import { DraftsService } from './drafts.service';
 import { AddDraftEntriesDto } from './dto/add-draft-entries.dto';
 import { CreateDraftDto } from './dto/create-draft.dto';
+import { ReorderDraftEntriesDto } from './dto/reorder-draft-entries.dto';
 import { UpdateDraftDto } from './dto/update-draft.dto';
 
 @Controller('drafts')
@@ -67,6 +68,21 @@ export class DraftsController {
     @Body() dto: AddDraftEntriesDto,
   ) {
     const draft = await this.draftsService.addEntriesToDraft(
+      user.userId,
+      draftId,
+      dto.entryIds,
+    );
+
+    return toPublicDraftDetail(draft);
+  }
+
+  @Patch(':draftId/entries/reorder')
+  async reorderDraftEntries(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('draftId') draftId: string,
+    @Body() dto: ReorderDraftEntriesDto,
+  ) {
+    const draft = await this.draftsService.reorderDraftEntries(
       user.userId,
       draftId,
       dto.entryIds,

--- a/apps/api/src/drafts/drafts.service.spec.ts
+++ b/apps/api/src/drafts/drafts.service.spec.ts
@@ -76,4 +76,164 @@ describe('DraftsService', () => {
       draftsService.addEntriesToDraft('user-1', 'draft-1', ['entry-1']),
     ).rejects.toBeInstanceOf(ConflictException);
   });
+
+  it('rejects reorder payloads that do not include the full draft entry set', async () => {
+    query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-1',
+            userId: 'user-1',
+            title: '초안',
+            description: null,
+            status: 'active',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            entryCount: 2,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-entry-1',
+            position: 1,
+            createdAt: new Date(),
+            entryId: 'entry-1',
+            entryUserId: 'user-1',
+            entryTitle: '첫 기록',
+            entryBody: '첫 문장',
+            entryStatus: 'draft',
+            entryCreatedAt: new Date(),
+            entryUpdatedAt: new Date(),
+            entryLastSavedAt: new Date(),
+          },
+          {
+            id: 'draft-entry-2',
+            position: 2,
+            createdAt: new Date(),
+            entryId: 'entry-2',
+            entryUserId: 'user-1',
+            entryTitle: '둘째 기록',
+            entryBody: '둘째 문장',
+            entryStatus: 'draft',
+            entryCreatedAt: new Date(),
+            entryUpdatedAt: new Date(),
+            entryLastSavedAt: new Date(),
+          },
+        ],
+      });
+
+    await expect(
+      draftsService.reorderDraftEntries('user-1', 'draft-1', ['entry-2']),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('reorders draft entries and returns the updated detail', async () => {
+    const initialUpdatedAt = new Date('2026-03-26T00:00:00.000Z');
+    const reorderedUpdatedAt = new Date('2026-03-26T00:10:00.000Z');
+    const entryCreatedAt = new Date('2026-03-25T00:00:00.000Z');
+    const draftEntryCreatedAt = new Date('2026-03-26T00:00:00.000Z');
+
+    query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-1',
+            userId: 'user-1',
+            title: '초안',
+            description: null,
+            status: 'active',
+            createdAt: initialUpdatedAt,
+            updatedAt: initialUpdatedAt,
+            entryCount: 2,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-entry-1',
+            position: 1,
+            createdAt: draftEntryCreatedAt,
+            entryId: 'entry-1',
+            entryUserId: 'user-1',
+            entryTitle: '첫 기록',
+            entryBody: '첫 문장',
+            entryStatus: 'draft',
+            entryCreatedAt: entryCreatedAt,
+            entryUpdatedAt: entryCreatedAt,
+            entryLastSavedAt: entryCreatedAt,
+          },
+          {
+            id: 'draft-entry-2',
+            position: 2,
+            createdAt: draftEntryCreatedAt,
+            entryId: 'entry-2',
+            entryUserId: 'user-1',
+            entryTitle: '둘째 기록',
+            entryBody: '둘째 문장',
+            entryStatus: 'draft',
+            entryCreatedAt: entryCreatedAt,
+            entryUpdatedAt: entryCreatedAt,
+            entryLastSavedAt: entryCreatedAt,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-1',
+            userId: 'user-1',
+            title: '초안',
+            description: null,
+            status: 'active',
+            createdAt: initialUpdatedAt,
+            updatedAt: reorderedUpdatedAt,
+            entryCount: 2,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-entry-2',
+            position: 1,
+            createdAt: draftEntryCreatedAt,
+            entryId: 'entry-2',
+            entryUserId: 'user-1',
+            entryTitle: '둘째 기록',
+            entryBody: '둘째 문장',
+            entryStatus: 'draft',
+            entryCreatedAt: entryCreatedAt,
+            entryUpdatedAt: entryCreatedAt,
+            entryLastSavedAt: entryCreatedAt,
+          },
+          {
+            id: 'draft-entry-1',
+            position: 2,
+            createdAt: draftEntryCreatedAt,
+            entryId: 'entry-1',
+            entryUserId: 'user-1',
+            entryTitle: '첫 기록',
+            entryBody: '첫 문장',
+            entryStatus: 'draft',
+            entryCreatedAt: entryCreatedAt,
+            entryUpdatedAt: entryCreatedAt,
+            entryLastSavedAt: entryCreatedAt,
+          },
+        ],
+      });
+
+    const draft = await draftsService.reorderDraftEntries('user-1', 'draft-1', [
+      'entry-2',
+      'entry-1',
+    ]);
+
+    expect(draft.entries.map((item) => item.entry.id)).toEqual(['entry-2', 'entry-1']);
+    expect(draft.entries.map((item) => item.position)).toEqual([1, 2]);
+  });
 });

--- a/apps/api/src/drafts/drafts.service.ts
+++ b/apps/api/src/drafts/drafts.service.ts
@@ -255,6 +255,51 @@ export class DraftsService {
     return this.findDraftById(userId, draftId);
   }
 
+  async reorderDraftEntries(
+    userId: string,
+    draftId: string,
+    entryIds: string[],
+  ): Promise<DraftDetailRecord> {
+    if (entryIds.length === 0) {
+      throw new BadRequestException('초안 순서를 바꾸려면 기록 순서가 필요합니다.');
+    }
+
+    await this.findDraftRecordById(userId, draftId);
+
+    const currentEntries = await this.listDraftEntries(draftId);
+    const currentEntryIds = currentEntries.map((draftEntry) => draftEntry.entry.id);
+
+    if (!hasSameEntrySet(currentEntryIds, entryIds)) {
+      throw new BadRequestException('초안에 담긴 기록 전체 순서를 그대로 보내야 합니다.');
+    }
+
+    let position = 0;
+
+    for (const entryId of entryIds) {
+      position += 1;
+
+      await this.databaseService.getPool().query(
+        `
+          UPDATE draft_entries
+          SET position = $3
+          WHERE draft_id = $1 AND entry_id = $2
+        `,
+        [draftId, entryId, position],
+      );
+    }
+
+    await this.databaseService.getPool().query(
+      `
+        UPDATE drafts
+        SET updated_at = NOW()
+        WHERE id = $1 AND user_id = $2
+      `,
+      [draftId, userId],
+    );
+
+    return this.findDraftById(userId, draftId);
+  }
+
   private async findDraftRecordById(userId: string, draftId: string): Promise<DraftRecord> {
     const result = await this.databaseService.getPool().query<DraftRow>(
       `
@@ -370,4 +415,18 @@ function normalizeOptionalText(value: string | undefined): string | null {
   const normalized = value.trim();
 
   return normalized.length > 0 ? normalized : null;
+}
+
+function hasSameEntrySet(currentEntryIds: string[], nextEntryIds: string[]) {
+  if (currentEntryIds.length !== nextEntryIds.length) {
+    return false;
+  }
+
+  const currentEntryIdSet = new Set(currentEntryIds);
+
+  if (currentEntryIdSet.size !== nextEntryIds.length) {
+    return false;
+  }
+
+  return nextEntryIds.every((entryId) => currentEntryIdSet.has(entryId));
 }

--- a/apps/api/src/drafts/dto/reorder-draft-entries.dto.ts
+++ b/apps/api/src/drafts/dto/reorder-draft-entries.dto.ts
@@ -1,0 +1,9 @@
+import { ArrayNotEmpty, ArrayUnique, IsArray, IsUUID } from 'class-validator';
+
+export class ReorderDraftEntriesDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @IsUUID('4', { each: true })
+  entryIds!: string[];
+}

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -165,6 +165,10 @@ class FakePool {
       return this.insertDraftEntry(values);
     }
 
+    if (normalizedQuery.startsWith('UPDATE draft_entries')) {
+      return this.updateDraftEntryPosition(values);
+    }
+
     if (
       normalizedQuery.includes('FROM entries WHERE user_id = $1 ORDER BY updated_at DESC')
     ) {
@@ -562,6 +566,27 @@ class FakePool {
     }
 
     draft.updatedAt = new Date();
+
+    return Promise.resolve({
+      rowCount: 1,
+    });
+  }
+
+  private updateDraftEntryPosition(values: unknown[]) {
+    const draftId = values[0] as string;
+    const entryId = values[1] as string;
+    const position = values[2] as number;
+    const draftEntry = [...this.draftEntriesById.values()].find(
+      (item) => item.draftId === draftId && item.entryId === entryId,
+    );
+
+    if (!draftEntry) {
+      return Promise.resolve({
+        rowCount: 0,
+      });
+    }
+
+    draftEntry.position = position;
 
     return Promise.resolve({
       rowCount: 1,
@@ -1023,6 +1048,29 @@ describe('AppController (e2e)', () => {
         entryIds: [firstEntry.id],
       })
       .expect(409);
+
+    const reorderResponse = await request(server)
+      .patch(`/api/drafts/${createdDraft.id}/entries/reorder`)
+      .set('Authorization', `Bearer ${auth.accessToken}`)
+      .send({
+        entryIds: [secondEntry.id, firstEntry.id],
+      })
+      .expect(200);
+    const reorderedDraft = reorderResponse.body as DraftDetailResponseBody;
+
+    expect(reorderedDraft.entries).toHaveLength(2);
+    expect(reorderedDraft.entries[0].position).toBe(1);
+    expect(reorderedDraft.entries[0].entry.id).toBe(secondEntry.id);
+    expect(reorderedDraft.entries[1].position).toBe(2);
+    expect(reorderedDraft.entries[1].entry.id).toBe(firstEntry.id);
+
+    await request(server)
+      .patch(`/api/drafts/${createdDraft.id}/entries/reorder`)
+      .set('Authorization', `Bearer ${auth.accessToken}`)
+      .send({
+        entryIds: [firstEntry.id],
+      })
+      .expect(400);
   });
 
   it('blocks access to another user draft and attached entries', async () => {
@@ -1073,6 +1121,14 @@ describe('AppController (e2e)', () => {
       .set('Authorization', `Bearer ${owner.accessToken}`)
       .send({
         entryIds: [strangerEntry.id],
+      })
+      .expect(404);
+
+    await request(server)
+      .patch(`/api/drafts/${ownerDraft.id}/entries/reorder`)
+      .set('Authorization', `Bearer ${stranger.accessToken}`)
+      .send({
+        entryIds: [ownerEntry.id],
       })
       .expect(404);
   });

--- a/apps/web/app/assets/css/main.css
+++ b/apps/web/app/assets/css/main.css
@@ -970,6 +970,23 @@ textarea {
   white-space: nowrap;
 }
 
+.sequence-tools {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+.sequence-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.sequence-action {
+  min-width: 72px;
+  padding: 8px 12px;
+}
+
 .draft-footer {
   max-width: 680px;
   margin-top: 32px;

--- a/apps/web/app/composables/useDrafts.spec.ts
+++ b/apps/web/app/composables/useDrafts.spec.ts
@@ -60,6 +60,7 @@ describe('useDrafts', () => {
         getDraft: vi.fn(),
         createDraft: vi.fn(),
         addEntriesToDraft: vi.fn(),
+        reorderDraftEntries: vi.fn(),
       },
     });
 
@@ -76,6 +77,7 @@ describe('useDrafts', () => {
         getDraft: vi.fn(),
         createDraft: vi.fn(),
         addEntriesToDraft: vi.fn(),
+        reorderDraftEntries: vi.fn(),
       },
     });
 
@@ -95,6 +97,7 @@ describe('useDrafts', () => {
         getDraft: vi.fn(),
         createDraft,
         addEntriesToDraft: vi.fn(),
+        reorderDraftEntries: vi.fn(),
       },
     });
 
@@ -114,6 +117,7 @@ describe('useDrafts', () => {
         getDraft: vi.fn().mockResolvedValue(createDraftDetailFixture()),
         createDraft: vi.fn(),
         addEntriesToDraft: vi.fn(),
+        reorderDraftEntries: vi.fn(),
       },
     });
 
@@ -131,6 +135,7 @@ describe('useDrafts', () => {
         getDraft: vi.fn().mockResolvedValue(createDraftDetailFixture()),
         createDraft: vi.fn(),
         addEntriesToDraft: vi.fn().mockRejectedValue(new Error('boom')),
+        reorderDraftEntries: vi.fn(),
       },
     });
 
@@ -138,5 +143,59 @@ describe('useDrafts', () => {
 
     expect(drafts.attachState.value).toBe('error');
     expect(drafts.attachError.value).toContain('초안에 담지 못했습니다');
+  });
+
+  it('reorders draft entries and syncs the current draft detail', async () => {
+    const drafts = useDrafts({
+      api: {
+        listDrafts: vi.fn().mockResolvedValue([]),
+        getDraft: vi.fn().mockResolvedValue(createDraftDetailFixture()),
+        createDraft: vi.fn(),
+        addEntriesToDraft: vi.fn(),
+        reorderDraftEntries: vi.fn().mockResolvedValue(
+          createDraftDetailFixture({
+            entries: [
+              {
+                id: 'draft-entry-2',
+                position: 1,
+                createdAt: '2026-03-26T00:00:00.000Z',
+                entry: {
+                  id: 'entry-2',
+                  title: '둘째 기록',
+                  body: '둘째 문장',
+                  status: 'draft',
+                  createdAt: '2026-03-25T00:00:00.000Z',
+                  updatedAt: '2026-03-25T00:00:00.000Z',
+                  lastSavedAt: '2026-03-25T00:00:00.000Z',
+                },
+              },
+              {
+                id: 'draft-entry-1',
+                position: 2,
+                createdAt: '2026-03-26T00:00:00.000Z',
+                entry: {
+                  id: 'entry-1',
+                  title: '창가에 남은 빛',
+                  body: '저녁빛이 식탁 위를 천천히 지나가던 순간.',
+                  status: 'draft',
+                  createdAt: '2026-03-25T00:00:00.000Z',
+                  updatedAt: '2026-03-25T00:00:00.000Z',
+                  lastSavedAt: '2026-03-25T00:00:00.000Z',
+                },
+              },
+            ],
+          }),
+        ),
+      },
+    });
+
+    await drafts.loadDraftDetail('draft-1');
+    await drafts.reorderDraftEntries('draft-1', ['entry-2', 'entry-1']);
+
+    expect(drafts.reorderState.value).toBe('idle');
+    expect(drafts.currentDraft.value?.entries.map((item) => item.entry.id)).toEqual([
+      'entry-2',
+      'entry-1',
+    ]);
   });
 });

--- a/apps/web/app/composables/useDrafts.ts
+++ b/apps/web/app/composables/useDrafts.ts
@@ -15,6 +15,7 @@ type DraftsApi = {
   getDraft(draftId: string): Promise<PublicDraftDetail>;
   createDraft(input: CreateDraftInput): Promise<PublicDraft>;
   addEntriesToDraft(draftId: string, entryIds: string[]): Promise<PublicDraftDetail>;
+  reorderDraftEntries(draftId: string, entryIds: string[]): Promise<PublicDraftDetail>;
 };
 
 type UseDraftsOptions = {
@@ -32,6 +33,8 @@ export function useDrafts(options: UseDraftsOptions) {
   const createError = ref('');
   const attachState = ref<DraftMutationState>('idle');
   const attachError = ref('');
+  const reorderState = ref<DraftMutationState>('idle');
+  const reorderError = ref('');
 
   async function loadDrafts() {
     listState.value = 'loading';
@@ -107,6 +110,26 @@ export function useDrafts(options: UseDraftsOptions) {
     }
   }
 
+  async function reorderDraftEntries(draftId: string, entryIds: string[]) {
+    reorderState.value = 'submitting';
+    reorderError.value = '';
+
+    try {
+      const draft = await options.api.reorderDraftEntries(draftId, entryIds);
+      currentDraft.value = draft;
+      syncDraft(draft);
+      reorderState.value = 'idle';
+
+      return draft;
+    } catch {
+      reorderState.value = 'error';
+      reorderError.value =
+        '초안 순서를 바꾸지 못했습니다. 잠시 후 다시 시도해 주세요.';
+
+      return null;
+    }
+  }
+
   function syncDraft(draft: PublicDraft) {
     const index = drafts.value.findIndex((item) => item.id === draft.id);
 
@@ -133,9 +156,12 @@ export function useDrafts(options: UseDraftsOptions) {
     createError,
     attachState,
     attachError,
+    reorderState,
+    reorderError,
     loadDrafts,
     loadDraftDetail,
     createDraft,
     addEntriesToDraft,
+    reorderDraftEntries,
   };
 }

--- a/apps/web/app/pages/app/drafts/[id].vue
+++ b/apps/web/app/pages/app/drafts/[id].vue
@@ -43,6 +43,9 @@ const {
   detailError,
   detailState,
   loadDraftDetail,
+  reorderDraftEntries,
+  reorderError,
+  reorderState,
 } = draftsStore;
 
 const draftId = computed(() => String(route.params.id));
@@ -124,6 +127,46 @@ function toggleEntrySelection(entryId: string, selected: boolean) {
 
 function buildOrderLabel(position: number) {
   return String(position).padStart(2, '0');
+}
+
+function canMoveEntry(index: number, direction: 'up' | 'down') {
+  if (!currentDraft.value || reorderState.value === 'submitting') {
+    return false;
+  }
+
+  return direction === 'up'
+    ? index > 0
+    : index < currentDraft.value.entries.length - 1;
+}
+
+async function moveDraftEntry(entryId: string, direction: 'up' | 'down') {
+  if (!currentDraft.value) {
+    return;
+  }
+
+  const currentEntryIds = currentDraft.value.entries.map((item) => item.entry.id);
+  const currentIndex = currentEntryIds.indexOf(entryId);
+
+  if (currentIndex === -1) {
+    return;
+  }
+
+  const nextIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+
+  if (nextIndex < 0 || nextIndex >= currentEntryIds.length) {
+    return;
+  }
+
+  const nextEntryIds = [...currentEntryIds];
+  const [movedEntryId] = nextEntryIds.splice(currentIndex, 1);
+
+  if (!movedEntryId) {
+    return;
+  }
+
+  nextEntryIds.splice(nextIndex, 0, movedEntryId);
+
+  await reorderDraftEntries(draftId.value, nextEntryIds);
 }
 
 async function loadDraftResources(nextDraftId: string) {
@@ -311,6 +354,10 @@ function handleEntrySelectionChange(entryId: string, event: Event) {
         <section>
           <div class="sequence-header">초안에 담긴 기록</div>
 
+          <p v-if="reorderState === 'error'" class="writer-alert writer-alert-error">
+            {{ reorderError }}
+          </p>
+
           <div v-if="currentDraft.entries.length === 0" class="archive-state-card">
             <p class="archive-state-copy">
               아직 이 초안에는 담긴 기록이 없습니다. 위에서 기록을 골라 첫 흐름을 만들어 보세요.
@@ -319,7 +366,7 @@ function handleEntrySelectionChange(entryId: string, event: Event) {
 
           <div v-else class="sequence-list">
             <article
-              v-for="draftEntry in currentDraft.entries"
+              v-for="(draftEntry, index) in currentDraft.entries"
               :key="draftEntry.id"
               class="sequence-item"
             >
@@ -330,8 +377,28 @@ function handleEntrySelectionChange(entryId: string, event: Event) {
                 </h2>
                 <p class="sequence-copy">{{ buildEntryPreview(draftEntry.entry.body) }}</p>
               </div>
-              <div class="sequence-tag">
-                {{ formatEntryDate(draftEntry.entry.updatedAt) }}
+              <div class="sequence-tools">
+                <div class="sequence-tag">
+                  {{ formatEntryDate(draftEntry.entry.updatedAt) }}
+                </div>
+                <div class="sequence-actions">
+                  <button
+                    class="button-ghost sequence-action"
+                    type="button"
+                    :disabled="!canMoveEntry(index, 'up')"
+                    @click="moveDraftEntry(draftEntry.entry.id, 'up')"
+                  >
+                    위로
+                  </button>
+                  <button
+                    class="button-ghost sequence-action"
+                    type="button"
+                    :disabled="!canMoveEntry(index, 'down')"
+                    @click="moveDraftEntry(draftEntry.entry.id, 'down')"
+                  >
+                    아래로
+                  </button>
+                </div>
               </div>
             </article>
           </div>

--- a/apps/web/app/types/drafts.ts
+++ b/apps/web/app/types/drafts.ts
@@ -30,3 +30,7 @@ export type CreateDraftInput = {
   description?: string;
   status?: DraftStatus;
 };
+
+export type ReorderDraftEntriesInput = {
+  entryIds: string[];
+};

--- a/apps/web/app/utils/api.ts
+++ b/apps/web/app/utils/api.ts
@@ -127,6 +127,18 @@ export function createDraftsApiClient(
         },
       );
     },
+    reorderDraftEntries(draftId: string, entryIds: string[]) {
+      return requestJson<PublicDraftDetail>(
+        fetcher,
+        baseUrl,
+        `/drafts/${draftId}/entries/reorder`,
+        {
+          method: 'PATCH',
+          body: { entryIds },
+          headers: createAuthHeaders(getAccessToken),
+        },
+      );
+    },
   };
 }
 


### PR DESCRIPTION
## 요약

초안 상세 화면에서 기록 순서를 실제로 바꿀 수 있도록 reorder API와 프론트 reorder UI를 연결하고, 순서 무결성과 ownership 경계를 테스트로 고정했습니다.

## 변경 내용

- `apps/api`에 `PATCH /drafts/:draftId/entries/reorder` 엔드포인트와 reorder DTO, draft entry position 재정렬 로직 추가
- reorder 요청이 초안에 담긴 전체 entry id 집합과 일치하는지 검증해 순서 무결성 경계 추가
- Drafts 서비스 테스트와 fake PostgreSQL/Redis 기반 e2e 테스트에 reorder 성공/실패/ownership 시나리오 보강
- `apps/web` draft API client와 `useDrafts` composable에 reorder mutation 상태와 오류 메시지 추가
- `/app/drafts/[id]` 상세 화면에 위/아래 이동 버튼을 연결하고 reorder 진행 중/실패 상태를 반영
- `WORKLOG.md`에 draft reorder flow 진행 상태 기록

## 왜 이 변경이 필요한가

Phase 5 Draft Flow와 MVP 범위에서 초안은 기록을 담는 것만으로는 충분하지 않고, 포함된 기록의 순서를 조정할 수 있어야 실제 책 초안을 다듬는 경험이 됩니다. 이번 변경은 preview 단계로 넘어가기 전에 draft organization의 핵심인 reorder를 API와 UI 양쪽에서 완성하기 위한 작업입니다.

## 확인 방법

- `pnpm --filter @book-maker/api lint`
- `pnpm --filter @book-maker/api typecheck`
- `pnpm --filter @book-maker/api test`
- `pnpm --filter @book-maker/api test:e2e`
- `pnpm --filter @book-maker/api build`
- `pnpm --filter @book-maker/web lint`
- `pnpm --filter @book-maker/web typecheck`
- `pnpm --filter @book-maker/web test`
- `pnpm --filter @book-maker/web build`

## 관련 문서 / 이슈

- Closes: #27
- Related: #25, #23
- Docs: WORKLOG.md

## 체크리스트

- [x] 현재 MVP 방향과 충돌하지 않는다
- [x] 기존 문서/구조와 정합성을 확인했다
- [x] 필요한 경우 문서를 함께 수정했다
- [x] 필요한 경우 테스트를 추가했거나 테스트 불필요 사유를 판단했다
- [x] lint / typecheck / test / build 영향을 확인했다

## 비고

- `pnpm --filter @book-maker/web typecheck`에서는 npm env warning이 있었지만 실패는 아니었습니다.
- `pnpm --filter @book-maker/web build`에서는 Nuxt sourcemap warning이 있었지만 빌드는 정상 완료됐습니다.
- 다음 후속 범위는 draft entry 제거 흐름과 preview API/UI 연결입니다.