### PR TITLE
feat: 초안 entry 제거 흐름 구현

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -10,6 +10,34 @@
 
 ---
 
+## 2026-03-27 (Draft entry removal flow)
+
+### 완료
+
+- 이슈 `#29` 기준 `apps/api`에 `DELETE /drafts/:draftId/entries/:entryId` 계약과 제거 후 position 재정렬 로직 추가
+- 초안 상세 화면에서 담긴 기록을 바로 뺄 수 있는 UI와 remove mutation 상태, 오류 메시지 연결
+- 제거 직후 초안 목록/상세 동기화와 빈 초안 상태 반영을 `useDrafts`에 연결
+- Drafts 서비스 테스트, fake PostgreSQL/Redis e2e, 프론트 composable 테스트에 remove 시나리오 보강
+
+### 현재 상태
+
+- 사용자는 초안 상세 화면에서 불필요한 기록을 제거하고 남은 기록 순서를 연속된 position으로 유지할 수 있다
+- Draft Organization MVP 범위의 add / reorder / remove 흐름이 API와 프론트 양쪽에서 모두 연결되었다
+- 다음 핵심 후속 범위는 preview API와 실제 preview 화면 연결이다
+
+### 다음 액션
+
+1. draft preview API를 추가해 초안을 연속 읽기 데이터로 변환한다
+2. `/app/drafts/preview`를 실제 draft 데이터에 연결해 책처럼 읽히는 화면을 만든다
+3. draft detail에서 preview 진입 흐름을 연결하고 관련 테스트를 보강한다
+
+### 메모
+
+- 검증은 `pnpm --filter @book-maker/api lint`, `typecheck`, `test`, `test:e2e`, `pnpm --filter @book-maker/web lint`, `typecheck`, `test` 기준으로 확인
+- reorder 검증은 remove 이후가 아니라 빈 payload 경계로 유지해 API 계약과 테스트 의도를 맞췄다
+
+---
+
 ## 2026-03-26 (Draft reorder flow)
 
 ### 완료

--- a/apps/api/src/drafts/drafts.controller.ts
+++ b/apps/api/src/drafts/drafts.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Patch,
@@ -87,6 +88,17 @@ export class DraftsController {
       draftId,
       dto.entryIds,
     );
+
+    return toPublicDraftDetail(draft);
+  }
+
+  @Delete(':draftId/entries/:entryId')
+  async removeDraftEntry(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('draftId') draftId: string,
+    @Param('entryId') entryId: string,
+  ) {
+    const draft = await this.draftsService.removeDraftEntry(user.userId, draftId, entryId);
 
     return toPublicDraftDetail(draft);
   }

--- a/apps/api/src/drafts/drafts.service.spec.ts
+++ b/apps/api/src/drafts/drafts.service.spec.ts
@@ -236,4 +236,136 @@ describe('DraftsService', () => {
     expect(draft.entries.map((item) => item.entry.id)).toEqual(['entry-2', 'entry-1']);
     expect(draft.entries.map((item) => item.position)).toEqual([1, 2]);
   });
+
+  it('throws when removing an entry that is not in the draft', async () => {
+    query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-1',
+            userId: 'user-1',
+            title: '초안',
+            description: null,
+            status: 'active',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            entryCount: 1,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-entry-1',
+            position: 1,
+            createdAt: new Date(),
+            entryId: 'entry-1',
+            entryUserId: 'user-1',
+            entryTitle: '첫 기록',
+            entryBody: '첫 문장',
+            entryStatus: 'draft',
+            entryCreatedAt: new Date(),
+            entryUpdatedAt: new Date(),
+            entryLastSavedAt: new Date(),
+          },
+        ],
+      });
+
+    await expect(
+      draftsService.removeDraftEntry('user-1', 'draft-1', 'entry-9'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('removes a draft entry, reorders positions, and returns the updated detail', async () => {
+    const initialUpdatedAt = new Date('2026-03-26T00:00:00.000Z');
+    const removedUpdatedAt = new Date('2026-03-26T00:10:00.000Z');
+    const entryCreatedAt = new Date('2026-03-25T00:00:00.000Z');
+    const draftEntryCreatedAt = new Date('2026-03-26T00:00:00.000Z');
+
+    query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-1',
+            userId: 'user-1',
+            title: '초안',
+            description: null,
+            status: 'active',
+            createdAt: initialUpdatedAt,
+            updatedAt: initialUpdatedAt,
+            entryCount: 2,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-entry-1',
+            position: 1,
+            createdAt: draftEntryCreatedAt,
+            entryId: 'entry-1',
+            entryUserId: 'user-1',
+            entryTitle: '첫 기록',
+            entryBody: '첫 문장',
+            entryStatus: 'draft',
+            entryCreatedAt: entryCreatedAt,
+            entryUpdatedAt: entryCreatedAt,
+            entryLastSavedAt: entryCreatedAt,
+          },
+          {
+            id: 'draft-entry-2',
+            position: 2,
+            createdAt: draftEntryCreatedAt,
+            entryId: 'entry-2',
+            entryUserId: 'user-1',
+            entryTitle: '둘째 기록',
+            entryBody: '둘째 문장',
+            entryStatus: 'draft',
+            entryCreatedAt: entryCreatedAt,
+            entryUpdatedAt: entryCreatedAt,
+            entryLastSavedAt: entryCreatedAt,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-1',
+            userId: 'user-1',
+            title: '초안',
+            description: null,
+            status: 'active',
+            createdAt: initialUpdatedAt,
+            updatedAt: removedUpdatedAt,
+            entryCount: 1,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-entry-2',
+            position: 1,
+            createdAt: draftEntryCreatedAt,
+            entryId: 'entry-2',
+            entryUserId: 'user-1',
+            entryTitle: '둘째 기록',
+            entryBody: '둘째 문장',
+            entryStatus: 'draft',
+            entryCreatedAt: entryCreatedAt,
+            entryUpdatedAt: entryCreatedAt,
+            entryLastSavedAt: entryCreatedAt,
+          },
+        ],
+      });
+
+    const draft = await draftsService.removeDraftEntry('user-1', 'draft-1', 'entry-1');
+
+    expect(draft.entryCount).toBe(1);
+    expect(draft.entries.map((item) => item.entry.id)).toEqual(['entry-2']);
+    expect(draft.entries.map((item) => item.position)).toEqual([1]);
+  });
 });

--- a/apps/api/src/drafts/drafts.service.ts
+++ b/apps/api/src/drafts/drafts.service.ts
@@ -300,6 +300,59 @@ export class DraftsService {
     return this.findDraftById(userId, draftId);
   }
 
+  async removeDraftEntry(
+    userId: string,
+    draftId: string,
+    entryId: string,
+  ): Promise<DraftDetailRecord> {
+    await this.findDraftRecordById(userId, draftId);
+
+    const currentEntries = await this.listDraftEntries(draftId);
+    const removedEntry = currentEntries.find((draftEntry) => draftEntry.entry.id === entryId);
+
+    if (!removedEntry) {
+      throw new NotFoundException('초안에 담긴 기록을 찾을 수 없습니다.');
+    }
+
+    await this.databaseService.getPool().query(
+      `
+        DELETE FROM draft_entries
+        WHERE draft_id = $1 AND entry_id = $2
+      `,
+      [draftId, entryId],
+    );
+
+    const remainingEntries = currentEntries.filter(
+      (draftEntry) => draftEntry.entry.id !== entryId,
+    );
+
+    let position = 0;
+
+    for (const draftEntry of remainingEntries) {
+      position += 1;
+
+      await this.databaseService.getPool().query(
+        `
+          UPDATE draft_entries
+          SET position = $3
+          WHERE draft_id = $1 AND entry_id = $2
+        `,
+        [draftId, draftEntry.entry.id, position],
+      );
+    }
+
+    await this.databaseService.getPool().query(
+      `
+        UPDATE drafts
+        SET updated_at = NOW()
+        WHERE id = $1 AND user_id = $2
+      `,
+      [draftId, userId],
+    );
+
+    return this.findDraftById(userId, draftId);
+  }
+
   private async findDraftRecordById(userId: string, draftId: string): Promise<DraftRecord> {
     const result = await this.databaseService.getPool().query<DraftRow>(
       `

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -165,6 +165,10 @@ class FakePool {
       return this.insertDraftEntry(values);
     }
 
+    if (normalizedQuery.startsWith('DELETE FROM draft_entries')) {
+      return this.deleteDraftEntry(values);
+    }
+
     if (normalizedQuery.startsWith('UPDATE draft_entries')) {
       return this.updateDraftEntryPosition(values);
     }
@@ -587,6 +591,26 @@ class FakePool {
     }
 
     draftEntry.position = position;
+
+    return Promise.resolve({
+      rowCount: 1,
+    });
+  }
+
+  private deleteDraftEntry(values: unknown[]) {
+    const draftId = values[0] as string;
+    const entryId = values[1] as string;
+    const draftEntry = [...this.draftEntriesById.values()].find(
+      (item) => item.draftId === draftId && item.entryId === entryId,
+    );
+
+    if (!draftEntry) {
+      return Promise.resolve({
+        rowCount: 0,
+      });
+    }
+
+    this.draftEntriesById.delete(draftEntry.id);
 
     return Promise.resolve({
       rowCount: 1,
@@ -1064,11 +1088,27 @@ describe('AppController (e2e)', () => {
     expect(reorderedDraft.entries[1].position).toBe(2);
     expect(reorderedDraft.entries[1].entry.id).toBe(firstEntry.id);
 
+    const removedDraftResponse = await request(server)
+      .delete(`/api/drafts/${createdDraft.id}/entries/${secondEntry.id}`)
+      .set('Authorization', `Bearer ${auth.accessToken}`)
+      .expect(200);
+    const removedDraft = removedDraftResponse.body as DraftDetailResponseBody;
+
+    expect(removedDraft.entryCount).toBe(1);
+    expect(removedDraft.entries).toHaveLength(1);
+    expect(removedDraft.entries[0].position).toBe(1);
+    expect(removedDraft.entries[0].entry.id).toBe(firstEntry.id);
+
+    await request(server)
+      .delete(`/api/drafts/${createdDraft.id}/entries/${secondEntry.id}`)
+      .set('Authorization', `Bearer ${auth.accessToken}`)
+      .expect(404);
+
     await request(server)
       .patch(`/api/drafts/${createdDraft.id}/entries/reorder`)
       .set('Authorization', `Bearer ${auth.accessToken}`)
       .send({
-        entryIds: [firstEntry.id],
+        entryIds: [],
       })
       .expect(400);
   });
@@ -1130,6 +1170,11 @@ describe('AppController (e2e)', () => {
       .send({
         entryIds: [ownerEntry.id],
       })
+      .expect(404);
+
+    await request(server)
+      .delete(`/api/drafts/${ownerDraft.id}/entries/${ownerEntry.id}`)
+      .set('Authorization', `Bearer ${stranger.accessToken}`)
       .expect(404);
   });
 });

--- a/apps/web/app/composables/useDrafts.spec.ts
+++ b/apps/web/app/composables/useDrafts.spec.ts
@@ -60,6 +60,7 @@ describe('useDrafts', () => {
         getDraft: vi.fn(),
         createDraft: vi.fn(),
         addEntriesToDraft: vi.fn(),
+        removeDraftEntry: vi.fn(),
         reorderDraftEntries: vi.fn(),
       },
     });
@@ -77,6 +78,7 @@ describe('useDrafts', () => {
         getDraft: vi.fn(),
         createDraft: vi.fn(),
         addEntriesToDraft: vi.fn(),
+        removeDraftEntry: vi.fn(),
         reorderDraftEntries: vi.fn(),
       },
     });
@@ -97,6 +99,7 @@ describe('useDrafts', () => {
         getDraft: vi.fn(),
         createDraft,
         addEntriesToDraft: vi.fn(),
+        removeDraftEntry: vi.fn(),
         reorderDraftEntries: vi.fn(),
       },
     });
@@ -117,6 +120,7 @@ describe('useDrafts', () => {
         getDraft: vi.fn().mockResolvedValue(createDraftDetailFixture()),
         createDraft: vi.fn(),
         addEntriesToDraft: vi.fn(),
+        removeDraftEntry: vi.fn(),
         reorderDraftEntries: vi.fn(),
       },
     });
@@ -135,6 +139,7 @@ describe('useDrafts', () => {
         getDraft: vi.fn().mockResolvedValue(createDraftDetailFixture()),
         createDraft: vi.fn(),
         addEntriesToDraft: vi.fn().mockRejectedValue(new Error('boom')),
+        removeDraftEntry: vi.fn(),
         reorderDraftEntries: vi.fn(),
       },
     });
@@ -145,6 +150,82 @@ describe('useDrafts', () => {
     expect(drafts.attachError.value).toContain('초안에 담지 못했습니다');
   });
 
+  it('removes a draft entry and syncs the current draft detail', async () => {
+    const drafts = useDrafts({
+      api: {
+        listDrafts: vi.fn().mockResolvedValue([]),
+        getDraft: vi.fn().mockResolvedValue(
+          createDraftDetailFixture({
+            entryCount: 2,
+            entries: [
+              {
+                id: 'draft-entry-1',
+                position: 1,
+                createdAt: '2026-03-26T00:00:00.000Z',
+                entry: {
+                  id: 'entry-1',
+                  title: '창가에 남은 빛',
+                  body: '저녁빛이 식탁 위를 천천히 지나가던 순간.',
+                  status: 'draft',
+                  createdAt: '2026-03-25T00:00:00.000Z',
+                  updatedAt: '2026-03-25T00:00:00.000Z',
+                  lastSavedAt: '2026-03-25T00:00:00.000Z',
+                },
+              },
+              {
+                id: 'draft-entry-2',
+                position: 2,
+                createdAt: '2026-03-26T00:00:00.000Z',
+                entry: {
+                  id: 'entry-2',
+                  title: '둘째 기록',
+                  body: '둘째 문장',
+                  status: 'draft',
+                  createdAt: '2026-03-25T00:00:00.000Z',
+                  updatedAt: '2026-03-25T00:00:00.000Z',
+                  lastSavedAt: '2026-03-25T00:00:00.000Z',
+                },
+              },
+            ],
+          }),
+        ),
+        createDraft: vi.fn(),
+        addEntriesToDraft: vi.fn(),
+        removeDraftEntry: vi.fn().mockResolvedValue(
+          createDraftDetailFixture({
+            entryCount: 1,
+            entries: [
+              {
+                id: 'draft-entry-2',
+                position: 1,
+                createdAt: '2026-03-26T00:00:00.000Z',
+                entry: {
+                  id: 'entry-2',
+                  title: '둘째 기록',
+                  body: '둘째 문장',
+                  status: 'draft',
+                  createdAt: '2026-03-25T00:00:00.000Z',
+                  updatedAt: '2026-03-25T00:00:00.000Z',
+                  lastSavedAt: '2026-03-25T00:00:00.000Z',
+                },
+              },
+            ],
+          }),
+        ),
+        reorderDraftEntries: vi.fn(),
+      },
+    });
+
+    await drafts.loadDraftDetail('draft-1');
+    await drafts.removeDraftEntry('draft-1', 'entry-1');
+
+    expect(drafts.removeState.value).toBe('idle');
+    expect(drafts.currentDraft.value?.entries.map((item) => item.entry.id)).toEqual([
+      'entry-2',
+    ]);
+    expect(drafts.currentDraft.value?.entries[0]?.position).toBe(1);
+  });
+
   it('reorders draft entries and syncs the current draft detail', async () => {
     const drafts = useDrafts({
       api: {
@@ -152,6 +233,7 @@ describe('useDrafts', () => {
         getDraft: vi.fn().mockResolvedValue(createDraftDetailFixture()),
         createDraft: vi.fn(),
         addEntriesToDraft: vi.fn(),
+        removeDraftEntry: vi.fn(),
         reorderDraftEntries: vi.fn().mockResolvedValue(
           createDraftDetailFixture({
             entries: [

--- a/apps/web/app/composables/useDrafts.ts
+++ b/apps/web/app/composables/useDrafts.ts
@@ -15,6 +15,7 @@ type DraftsApi = {
   getDraft(draftId: string): Promise<PublicDraftDetail>;
   createDraft(input: CreateDraftInput): Promise<PublicDraft>;
   addEntriesToDraft(draftId: string, entryIds: string[]): Promise<PublicDraftDetail>;
+  removeDraftEntry(draftId: string, entryId: string): Promise<PublicDraftDetail>;
   reorderDraftEntries(draftId: string, entryIds: string[]): Promise<PublicDraftDetail>;
 };
 
@@ -33,6 +34,8 @@ export function useDrafts(options: UseDraftsOptions) {
   const createError = ref('');
   const attachState = ref<DraftMutationState>('idle');
   const attachError = ref('');
+  const removeState = ref<DraftMutationState>('idle');
+  const removeError = ref('');
   const reorderState = ref<DraftMutationState>('idle');
   const reorderError = ref('');
 
@@ -130,6 +133,26 @@ export function useDrafts(options: UseDraftsOptions) {
     }
   }
 
+  async function removeDraftEntry(draftId: string, entryId: string) {
+    removeState.value = 'submitting';
+    removeError.value = '';
+
+    try {
+      const draft = await options.api.removeDraftEntry(draftId, entryId);
+      currentDraft.value = draft;
+      syncDraft(draft);
+      removeState.value = 'idle';
+
+      return draft;
+    } catch {
+      removeState.value = 'error';
+      removeError.value =
+        '초안에서 기록을 빼지 못했습니다. 잠시 후 다시 시도해 주세요.';
+
+      return null;
+    }
+  }
+
   function syncDraft(draft: PublicDraft) {
     const index = drafts.value.findIndex((item) => item.id === draft.id);
 
@@ -156,12 +179,15 @@ export function useDrafts(options: UseDraftsOptions) {
     createError,
     attachState,
     attachError,
+    removeState,
+    removeError,
     reorderState,
     reorderError,
     loadDrafts,
     loadDraftDetail,
     createDraft,
     addEntriesToDraft,
+    removeDraftEntry,
     reorderDraftEntries,
   };
 }

--- a/apps/web/app/pages/app/drafts/[id].vue
+++ b/apps/web/app/pages/app/drafts/[id].vue
@@ -43,6 +43,9 @@ const {
   detailError,
   detailState,
   loadDraftDetail,
+  removeDraftEntry,
+  removeError,
+  removeState,
   reorderDraftEntries,
   reorderError,
   reorderState,
@@ -130,7 +133,11 @@ function buildOrderLabel(position: number) {
 }
 
 function canMoveEntry(index: number, direction: 'up' | 'down') {
-  if (!currentDraft.value || reorderState.value === 'submitting') {
+  if (
+    !currentDraft.value ||
+    reorderState.value === 'submitting' ||
+    removeState.value === 'submitting'
+  ) {
     return false;
   }
 
@@ -167,6 +174,14 @@ async function moveDraftEntry(entryId: string, direction: 'up' | 'down') {
   nextEntryIds.splice(nextIndex, 0, movedEntryId);
 
   await reorderDraftEntries(draftId.value, nextEntryIds);
+}
+
+async function handleDraftEntryRemove(entryId: string) {
+  if (!currentDraft.value || removeState.value === 'submitting') {
+    return;
+  }
+
+  await removeDraftEntry(draftId.value, entryId);
 }
 
 async function loadDraftResources(nextDraftId: string) {
@@ -354,6 +369,9 @@ function handleEntrySelectionChange(entryId: string, event: Event) {
         <section>
           <div class="sequence-header">초안에 담긴 기록</div>
 
+          <p v-if="removeState === 'error'" class="writer-alert writer-alert-error">
+            {{ removeError }}
+          </p>
           <p v-if="reorderState === 'error'" class="writer-alert writer-alert-error">
             {{ reorderError }}
           </p>
@@ -397,6 +415,14 @@ function handleEntrySelectionChange(entryId: string, event: Event) {
                     @click="moveDraftEntry(draftEntry.entry.id, 'down')"
                   >
                     아래로
+                  </button>
+                  <button
+                    class="button-ghost sequence-action"
+                    type="button"
+                    :disabled="removeState === 'submitting'"
+                    @click="handleDraftEntryRemove(draftEntry.entry.id)"
+                  >
+                    {{ removeState === 'submitting' ? '빼는 중...' : '빼기' }}
                   </button>
                 </div>
               </div>

--- a/apps/web/app/utils/api.ts
+++ b/apps/web/app/utils/api.ts
@@ -127,6 +127,17 @@ export function createDraftsApiClient(
         },
       );
     },
+    removeDraftEntry(draftId: string, entryId: string) {
+      return requestJson<PublicDraftDetail>(
+        fetcher,
+        baseUrl,
+        `/drafts/${draftId}/entries/${entryId}`,
+        {
+          method: 'DELETE',
+          headers: createAuthHeaders(getAccessToken),
+        },
+      );
+    },
     reorderDraftEntries(draftId: string, entryIds: string[]) {
       return requestJson<PublicDraftDetail>(
         fetcher,


### PR DESCRIPTION
## 요약

초안 상세 화면에서 담긴 기록을 제거할 수 있도록 draft entry 제거 API와 프론트 remove 흐름을 추가했습니다. 제거 직후 남은 기록의 순서를 다시 정렬하고 목록/상세 상태를 함께 동기화해 Draft Organization MVP 범위를 마무리했습니다.

## 변경 내용

- `apps/api`에 `DELETE /drafts/:draftId/entries/:entryId` 계약과 제거 후 `position` 재정렬 로직을 추가했습니다.
- 초안 ownership, 존재하지 않는 draft entry, remove 이후 순서 유지 경계를 서비스 테스트와 e2e 테스트로 보강했습니다.
- `apps/web` draft API client와 `useDrafts`에 remove mutation 상태 및 오류 메시지를 추가했습니다.
- 초안 상세 화면에 `빼기` 액션을 연결하고 remove 이후 빈 상태와 목록/상세 동기화를 반영했습니다.
- `WORKLOG.md`에 이번 이슈 진행 내용과 다음 preview 후속 작업을 기록했습니다.

## 왜 이 변경이 필요한가

MVP의 Draft Organization 범위는 기록 추가와 reorder만으로 끝나지 않고, 불필요한 기록을 제거해 초안을 실제로 다듬을 수 있어야 합니다. 이번 변경은 Phase 5에서 요구한 add / reorder / remove 흐름을 연결해 preview 단계로 넘어가기 위한 마지막 정리 작업입니다.

## 확인 방법

- `pnpm --filter @book-maker/api lint`
- `pnpm --filter @book-maker/api typecheck`
- `pnpm --filter @book-maker/api test`
- `pnpm --filter @book-maker/api test:e2e`
- `pnpm --filter @book-maker/web lint`
- `pnpm --filter @book-maker/web typecheck`
- `pnpm --filter @book-maker/web test`
- `pnpm --filter @book-maker/api build`, `pnpm --filter @book-maker/web build`는 이번 PR에서 실행하지 않았습니다.

## 관련 문서 / 이슈

- Closes: #29
- Related: #23, #25, #27
- Docs: `WORKLOG.md`

## 체크리스트

- [x] 현재 MVP 방향과 충돌하지 않는다
- [x] 기존 문서/구조와 정합성을 확인했다
- [x] 필요한 경우 문서를 함께 수정했다
- [x] 필요한 경우 테스트를 추가했거나 테스트 불필요 사유를 판단했다
- [ ] lint / typecheck / test / build 영향을 확인했다

## 비고

- API e2e 검증에서 remove 이후 reorder `400` 기대값은 실제 계약과 맞지 않아 빈 payload `400` 검증으로 조정했습니다.
- 다음 후속 범위는 draft preview API와 실제 preview 화면 연결입니다.
