### PR TITLE
feat: 초안 미리보기 흐름 구현

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -10,6 +10,34 @@
 
 ---
 
+## 2026-03-27 (Draft preview flow)
+
+### 완료
+
+- 이슈 `#31` 기준 `apps/api`에 `GET /drafts/:id/preview` 계약과 preview 응답 타입을 추가
+- 초안 ownership과 존재하지 않는 draft 경계를 유지한 채 ordered entry를 연속 읽기용 preview 데이터로 변환
+- `apps/web/app/pages/app/drafts/preview.vue`를 실제 API 기반 화면으로 교체하고 draft detail에서 preview 진입 링크 연결
+- `useDraftPreview` composable과 관련 단위 테스트를 추가하고 preview reading layout을 실제 초안 데이터에 맞게 보강
+
+### 현재 상태
+
+- 사용자는 초안 상세 화면에서 바로 미리보기로 이동해 제목과 기록 본문을 한 권의 시작처럼 연속해서 읽어볼 수 있다
+- Draft Flow 이후 MVP 핵심 루프가 preview 단계까지 이어져 `write -> archive -> draft -> preview` 흐름이 실제 코드로 연결되었다
+- 남은 주요 MVP 화면 범위는 랜딩 페이지 실제 구현과 preview 경험 세부 다듬기 정도다
+
+### 다음 액션
+
+1. draft preview에서 detail로 복귀하는 흐름과 reading polish를 필요한 범위만 다듬는다
+2. 랜딩 페이지를 실제 Nuxt 화면으로 옮겨 MVP 주요 화면 구현을 마무리한다
+3. 필요하면 preview 핵심 흐름에 대한 E2E 시나리오를 후속 이슈로 추가한다
+
+### 메모
+
+- 검증은 `pnpm --filter @book-maker/api lint`, `typecheck`, `test`, `test:e2e`, `build`, `pnpm --filter @book-maker/web lint`, `typecheck`, `test`, `build` 기준으로 확인
+- web build는 Nuxt `module-preload-polyfill` sourcemap 경고가 있었지만 빌드는 정상 완료됐다
+
+---
+
 ## 2026-03-27 (Draft entry removal flow)
 
 ### 완료

--- a/apps/api/src/drafts/draft.types.ts
+++ b/apps/api/src/drafts/draft.types.ts
@@ -35,6 +35,19 @@ export type DraftDetailRecord = DraftRecord & {
   entries: DraftEntryRecord[];
 };
 
+export type DraftPreviewRecord = {
+  id: string;
+  title: string;
+  description: string | null;
+  updatedAt: Date;
+  entries: Array<{
+    id: string;
+    position: number;
+    title: string | null;
+    body: string;
+  }>;
+};
+
 export type PublicDraft = {
   id: string;
   title: string;
@@ -54,6 +67,19 @@ export type PublicDraftEntry = {
 
 export type PublicDraftDetail = PublicDraft & {
   entries: PublicDraftEntry[];
+};
+
+export type PublicDraftPreview = {
+  id: string;
+  title: string;
+  description: string | null;
+  updatedAt: string;
+  entries: Array<{
+    id: string;
+    position: number;
+    title: string | null;
+    body: string;
+  }>;
 };
 
 export function toPublicDraft(draft: DraftRecord): PublicDraft {
@@ -76,6 +102,21 @@ export function toPublicDraftDetail(draft: DraftDetailRecord): PublicDraftDetail
       position: draftEntry.position,
       createdAt: draftEntry.createdAt.toISOString(),
       entry: toPublicEntry(draftEntry.entry),
+    })),
+  };
+}
+
+export function toPublicDraftPreview(draft: DraftPreviewRecord): PublicDraftPreview {
+  return {
+    id: draft.id,
+    title: draft.title,
+    description: draft.description,
+    updatedAt: draft.updatedAt.toISOString(),
+    entries: draft.entries.map((entry) => ({
+      id: entry.id,
+      position: entry.position,
+      title: entry.title,
+      body: entry.body,
     })),
   };
 }

--- a/apps/api/src/drafts/drafts.controller.ts
+++ b/apps/api/src/drafts/drafts.controller.ts
@@ -12,7 +12,11 @@ import {
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { AuthGuard } from '../auth/guards/auth.guard';
-import { toPublicDraft, toPublicDraftDetail } from './draft.types';
+import {
+  toPublicDraft,
+  toPublicDraftDetail,
+  toPublicDraftPreview,
+} from './draft.types';
 import { DraftsService } from './drafts.service';
 import { AddDraftEntriesDto } from './dto/add-draft-entries.dto';
 import { CreateDraftDto } from './dto/create-draft.dto';
@@ -39,6 +43,16 @@ export class DraftsController {
     const drafts = await this.draftsService.listDrafts(user.userId);
 
     return drafts.map(toPublicDraft);
+  }
+
+  @Get(':draftId/preview')
+  async previewDraft(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('draftId') draftId: string,
+  ) {
+    const draft = await this.draftsService.previewDraft(user.userId, draftId);
+
+    return toPublicDraftPreview(draft);
   }
 
   @Get(':draftId')

--- a/apps/api/src/drafts/drafts.service.spec.ts
+++ b/apps/api/src/drafts/drafts.service.spec.ts
@@ -368,4 +368,65 @@ describe('DraftsService', () => {
     expect(draft.entries.map((item) => item.entry.id)).toEqual(['entry-2']);
     expect(draft.entries.map((item) => item.position)).toEqual([1]);
   });
+
+  it('builds a draft preview response from ordered draft entries', async () => {
+    const updatedAt = new Date('2026-03-27T00:10:00.000Z');
+    const entryCreatedAt = new Date('2026-03-25T00:00:00.000Z');
+    const draftEntryCreatedAt = new Date('2026-03-26T00:00:00.000Z');
+
+    query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-1',
+            userId: 'user-1',
+            title: '초안',
+            description: '바다의 결',
+            status: 'active',
+            createdAt: updatedAt,
+            updatedAt,
+            entryCount: 2,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'draft-entry-1',
+            position: 1,
+            createdAt: draftEntryCreatedAt,
+            entryId: 'entry-1',
+            entryUserId: 'user-1',
+            entryTitle: '첫 기록',
+            entryBody: '첫 문장',
+            entryStatus: 'draft',
+            entryCreatedAt: entryCreatedAt,
+            entryUpdatedAt: entryCreatedAt,
+            entryLastSavedAt: entryCreatedAt,
+          },
+          {
+            id: 'draft-entry-2',
+            position: 2,
+            createdAt: draftEntryCreatedAt,
+            entryId: 'entry-2',
+            entryUserId: 'user-1',
+            entryTitle: null,
+            entryBody: '둘째 문장',
+            entryStatus: 'draft',
+            entryCreatedAt: entryCreatedAt,
+            entryUpdatedAt: entryCreatedAt,
+            entryLastSavedAt: entryCreatedAt,
+          },
+        ],
+      });
+
+    const preview = await draftsService.previewDraft('user-1', 'draft-1');
+
+    expect(preview.title).toBe('초안');
+    expect(preview.description).toBe('바다의 결');
+    expect(preview.entries).toEqual([
+      { id: 'entry-1', position: 1, title: '첫 기록', body: '첫 문장' },
+      { id: 'entry-2', position: 2, title: null, body: '둘째 문장' },
+    ]);
+  });
 });

--- a/apps/api/src/drafts/drafts.service.ts
+++ b/apps/api/src/drafts/drafts.service.ts
@@ -10,6 +10,7 @@ import { DatabaseService } from '../infrastructure/database/database.service';
 import {
   DraftDetailRecord,
   DraftEntryRecord,
+  DraftPreviewRecord,
   DraftRecord,
   DraftStatus,
 } from './draft.types';
@@ -123,6 +124,23 @@ export class DraftsService {
     return {
       ...draft,
       entries,
+    };
+  }
+
+  async previewDraft(userId: string, draftId: string): Promise<DraftPreviewRecord> {
+    const draft = await this.findDraftById(userId, draftId);
+
+    return {
+      id: draft.id,
+      title: draft.title,
+      description: draft.description,
+      updatedAt: draft.updatedAt,
+      entries: draft.entries.map((draftEntry) => ({
+        id: draftEntry.entry.id,
+        position: draftEntry.position,
+        title: draftEntry.entry.title,
+        body: draftEntry.entry.body,
+      })),
     };
   }
 

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -105,6 +105,19 @@ type DraftDetailResponseBody = DraftResponseBody & {
   }>;
 };
 
+type DraftPreviewResponseBody = {
+  id: string;
+  title: string;
+  description: string | null;
+  updatedAt: string;
+  entries: Array<{
+    id: string;
+    position: number;
+    title: string | null;
+    body: string;
+  }>;
+};
+
 type StoredDraft = {
   id: string;
   userId: string;
@@ -1099,6 +1112,22 @@ describe('AppController (e2e)', () => {
     expect(removedDraft.entries[0].position).toBe(1);
     expect(removedDraft.entries[0].entry.id).toBe(firstEntry.id);
 
+    const previewResponse = await request(server)
+      .get(`/api/drafts/${createdDraft.id}/preview`)
+      .set('Authorization', `Bearer ${auth.accessToken}`)
+      .expect(200);
+    const previewBody = previewResponse.body as DraftPreviewResponseBody;
+
+    expect(previewBody.title).toBe('고요한 파도');
+    expect(previewBody.entries).toEqual([
+      {
+        id: firstEntry.id,
+        position: 1,
+        title: firstEntry.title,
+        body: firstEntry.body,
+      },
+    ]);
+
     await request(server)
       .delete(`/api/drafts/${createdDraft.id}/entries/${secondEntry.id}`)
       .set('Authorization', `Bearer ${auth.accessToken}`)
@@ -1174,6 +1203,11 @@ describe('AppController (e2e)', () => {
 
     await request(server)
       .delete(`/api/drafts/${ownerDraft.id}/entries/${ownerEntry.id}`)
+      .set('Authorization', `Bearer ${stranger.accessToken}`)
+      .expect(404);
+
+    await request(server)
+      .get(`/api/drafts/${ownerDraft.id}/preview`)
       .set('Authorization', `Bearer ${stranger.accessToken}`)
       .expect(404);
   });

--- a/apps/web/app/assets/css/main.css
+++ b/apps/web/app/assets/css/main.css
@@ -1226,6 +1226,11 @@ textarea {
   line-height: 1.75;
 }
 
+.preview-timestamp {
+  margin-top: 12px;
+  font-size: 13px;
+}
+
 .preview-divider {
   width: 48px;
   height: 1px;

--- a/apps/web/app/composables/useDraftPreview.spec.ts
+++ b/apps/web/app/composables/useDraftPreview.spec.ts
@@ -1,0 +1,50 @@
+import {
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import { useDraftPreview } from './useDraftPreview';
+
+describe('useDraftPreview', () => {
+  it('loads draft preview data', async () => {
+    const draftPreview = useDraftPreview({
+      api: {
+        getDraftPreview: vi.fn().mockResolvedValue({
+          id: 'draft-1',
+          title: '고요가 머무는 자리',
+          description: '바다를 따라 읽는 초안',
+          updatedAt: '2026-03-27T00:00:00.000Z',
+          entries: [
+            {
+              id: 'entry-1',
+              position: 1,
+              title: '첫 기록',
+              body: '첫 문장',
+            },
+          ],
+        }),
+      },
+    });
+
+    const preview = await draftPreview.loadPreview('draft-1');
+
+    expect(preview?.title).toBe('고요가 머무는 자리');
+    expect(draftPreview.previewState.value).toBe('loaded');
+    expect(draftPreview.preview.value?.entries).toHaveLength(1);
+  });
+
+  it('exposes an error when preview loading fails', async () => {
+    const draftPreview = useDraftPreview({
+      api: {
+        getDraftPreview: vi.fn().mockRejectedValue(new Error('boom')),
+      },
+    });
+
+    await draftPreview.loadPreview('draft-1');
+
+    expect(draftPreview.previewState.value).toBe('error');
+    expect(draftPreview.previewError.value).toContain('초안 미리보기를 불러오지 못했습니다');
+  });
+});

--- a/apps/web/app/composables/useDraftPreview.ts
+++ b/apps/web/app/composables/useDraftPreview.ts
@@ -1,0 +1,46 @@
+import { ref } from 'vue';
+
+import type { PublicDraftPreview } from '../types/drafts';
+
+export type DraftPreviewState = 'idle' | 'loading' | 'loaded' | 'error';
+
+type DraftPreviewApi = {
+  getDraftPreview(draftId: string): Promise<PublicDraftPreview>;
+};
+
+type UseDraftPreviewOptions = {
+  api: DraftPreviewApi;
+};
+
+export function useDraftPreview(options: UseDraftPreviewOptions) {
+  const preview = ref<PublicDraftPreview | null>(null);
+  const previewState = ref<DraftPreviewState>('idle');
+  const previewError = ref('');
+
+  async function loadPreview(draftId: string) {
+    previewState.value = 'loading';
+    previewError.value = '';
+
+    try {
+      const nextPreview = await options.api.getDraftPreview(draftId);
+      preview.value = nextPreview;
+      previewState.value = 'loaded';
+
+      return nextPreview;
+    } catch {
+      preview.value = null;
+      previewState.value = 'error';
+      previewError.value =
+        '초안 미리보기를 불러오지 못했습니다. 초안 상세 화면에서 다시 시도해 주세요.';
+
+      return null;
+    }
+  }
+
+  return {
+    preview,
+    previewState,
+    previewError,
+    loadPreview,
+  };
+}

--- a/apps/web/app/pages/app/drafts/[id].vue
+++ b/apps/web/app/pages/app/drafts/[id].vue
@@ -252,6 +252,12 @@ function handleEntrySelectionChange(entryId: string, event: Event) {
           </p>
         </div>
         <div class="page-tools">
+          <NuxtLink
+            class="button-primary"
+            :to="`/app/drafts/preview?draftId=${draftId}`"
+          >
+            미리보기
+          </NuxtLink>
           <NuxtLink class="button-ghost" to="/app/drafts">목록으로</NuxtLink>
           <NuxtLink class="button-ghost" to="/app/archive">아카이브</NuxtLink>
         </div>
@@ -306,6 +312,14 @@ function handleEntrySelectionChange(entryId: string, event: Event) {
             <span>기록 {{ currentDraft.entries.length }}개</span>
             <span>{{ currentDraft.status === 'active' ? '활성' : '보관' }}</span>
             <span>{{ formatEntryDateTime(currentDraft.updatedAt) }}</span>
+          </div>
+          <div class="draft-create-actions">
+            <NuxtLink
+              class="button-primary"
+              :to="`/app/drafts/preview?draftId=${draftId}`"
+            >
+              책처럼 읽어보기
+            </NuxtLink>
           </div>
         </div>
 

--- a/apps/web/app/pages/app/drafts/preview.vue
+++ b/apps/web/app/pages/app/drafts/preview.vue
@@ -1,55 +1,154 @@
 <script setup lang="ts">
+import { computed, watch } from 'vue';
+
+import { useAuthSession } from '../../../composables/useAuthSession';
+import { useDraftPreview } from '../../../composables/useDraftPreview';
+import { createDraftsApiClient } from '../../../utils/api';
+import { formatEntryDateTime } from '../../../utils/entry-format';
+
 definePageMeta({ layout: 'app' });
+
+const runtimeConfig = useRuntimeConfig();
+const route = useRoute();
+
+const {
+  hydrated,
+  isAuthenticated,
+  accessToken,
+  hydrateFromStorage,
+} = useAuthSession();
+
+const draftId = computed(() => {
+  const value = route.query.draftId;
+  return typeof value === 'string' && value.length > 0 ? value : '';
+});
+const draftsApi = createDraftsApiClient(
+  runtimeConfig.public.apiBase,
+  () => accessToken.value,
+);
+const {
+  loadPreview,
+  preview,
+  previewError,
+  previewState,
+} = useDraftPreview({
+  api: draftsApi,
+});
+const backLink = computed(() =>
+  draftId.value ? `/app/drafts/${draftId.value}` : '/app/drafts',
+);
+
+watch(
+  [hydrated, isAuthenticated, draftId],
+  async ([isHydrated, authenticated, nextDraftId]) => {
+    if (!isHydrated || !authenticated || !nextDraftId) {
+      return;
+    }
+
+    await loadPreview(nextDraftId);
+  },
+  { immediate: true },
+);
+
+onMounted(() => {
+  hydrateFromStorage();
+});
+
+async function reloadPreview() {
+  if (!draftId.value) {
+    return;
+  }
+
+  await loadPreview(draftId.value);
+}
+
+function buildPreviewParagraphs(body: string) {
+  return body
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0);
+}
 </script>
 
 <template>
   <main class="preview-shell">
-    <NuxtLink class="back-link" to="/app/drafts">초안으로</NuxtLink>
+    <NuxtLink class="back-link" :to="backLink">초안으로</NuxtLink>
 
-    <header class="preview-header">
-      <span class="preview-eyebrow">미리보기</span>
-      <h1 class="preview-title">고요가 머무는 자리</h1>
-      <p class="preview-copy">글의 흐름을 처음부터 끝까지 읽어 보세요.</p>
-      <div class="preview-divider" />
-    </header>
-
-    <article class="manuscript">
-      <section>
-        <h2>창가에 남은 빛</h2>
-        <p>
-          저녁빛이 식탁 위를 지나가던 순간은 생각보다 오래 남았다. 사라지는 것은 늘 빠르지만,
-          사라지기 직전의 장면은 이상하게 더 선명해진다.
-        </p>
-        <p>어쩌면 기억은 사건이 아니라 빛의 방향을 저장하는 일인지도 모른다.</p>
-      </section>
-
-      <div class="manuscript-sep">· · ·</div>
-
-      <section>
-        <h2>대답 없는 전화</h2>
-        <p>
-          받지 못한 전화는 금방 잊히지만, 받지 못한 이유를 오래 설명하게 되는 밤이 있다. 말해지지
-          않은 대답이 더 오래 남는 순간들.
-        </p>
-        <p>전화기를 내려놓고 나서도 울림은 한동안 손 안에 남아 있었다.</p>
-      </section>
-
-      <div class="manuscript-sep">· · ·</div>
-
-      <section>
-        <h2>메모해 두고 싶었던 문장</h2>
-        <p>
-          우리는 대체로 큰 사건보다 작은 반복 속에서 변해 간다. 습관이 성격을 만들고, 성격이 선택을
-          만들고, 선택이 기억을 만든다.
-        </p>
-        <p>메모는 그 반복의 증거다.</p>
-      </section>
-    </article>
-
-    <div class="preview-end">
-      <div class="preview-meta">여기까지입니다</div>
-      <p>목록이 아니라 한 권처럼 읽히는지 확인해 보세요.</p>
-      <NuxtLink class="button-secondary" to="/app/drafts">다시 다듬기</NuxtLink>
+    <div v-if="!hydrated" class="archive-state-card">
+      <p class="archive-state-copy">저장된 세션을 확인하고 있습니다.</p>
     </div>
+
+    <div v-else-if="!isAuthenticated" class="archive-state-card">
+      <p class="archive-state-copy">초안 미리보기를 보려면 먼저 로그인해야 합니다.</p>
+      <NuxtLink class="button-primary" to="/app/write">기록하기로 이동</NuxtLink>
+    </div>
+
+    <div v-else-if="!draftId" class="archive-state-card">
+      <p class="archive-state-copy">
+        미리볼 초안을 먼저 선택해 주세요. 초안 상세 화면에서 다시 진입할 수 있습니다.
+      </p>
+      <NuxtLink class="button-primary" to="/app/drafts">초안 목록으로</NuxtLink>
+    </div>
+
+    <div
+      v-else-if="previewState === 'loading' || previewState === 'idle'"
+      class="archive-state-card"
+    >
+      <p class="archive-state-copy">초안 미리보기를 준비하는 중입니다.</p>
+    </div>
+
+    <div v-else-if="previewState === 'error'" class="archive-state-card">
+      <p class="archive-state-copy">{{ previewError }}</p>
+      <button class="button-ghost" type="button" @click="reloadPreview">
+        다시 불러오기
+      </button>
+    </div>
+
+    <template v-else-if="preview">
+      <header class="preview-header">
+        <span class="preview-eyebrow">미리보기</span>
+        <h1 class="preview-title">{{ preview.title }}</h1>
+        <p class="preview-copy">
+          {{
+            preview.description ??
+            '글의 흐름을 처음부터 끝까지 읽으며 한 권의 시작처럼 느껴지는지 확인해 보세요.'
+          }}
+        </p>
+        <p class="preview-copy preview-timestamp">
+          마지막 정리 {{ formatEntryDateTime(preview.updatedAt) }}
+        </p>
+        <div class="preview-divider" />
+      </header>
+
+      <article class="manuscript">
+        <template v-if="preview.entries.length > 0">
+          <template v-for="(entry, index) in preview.entries" :key="entry.id">
+            <section>
+              <h2>{{ entry.title ?? `장면 ${String(entry.position).padStart(2, '0')}` }}</h2>
+              <p
+                v-for="(paragraph, paragraphIndex) in buildPreviewParagraphs(entry.body)"
+                :key="`${entry.id}-${paragraphIndex}`"
+              >
+                {{ paragraph }}
+              </p>
+            </section>
+
+            <div v-if="index < preview.entries.length - 1" class="manuscript-sep">· · ·</div>
+          </template>
+        </template>
+
+        <div v-else class="archive-state-card">
+          <p class="archive-state-copy">
+            아직 초안에 담긴 기록이 없습니다. 초안 상세 화면으로 돌아가 기록을 먼저 모아 보세요.
+          </p>
+        </div>
+      </article>
+
+      <div class="preview-end">
+        <div class="preview-meta">여기까지입니다</div>
+        <p>목록이 아니라 한 권처럼 읽히는지 확인해 보세요.</p>
+        <NuxtLink class="button-secondary" :to="backLink">다시 다듬기</NuxtLink>
+      </div>
+    </template>
   </main>
 </template>

--- a/apps/web/app/types/drafts.ts
+++ b/apps/web/app/types/drafts.ts
@@ -25,6 +25,19 @@ export type PublicDraftDetail = PublicDraft & {
   entries: PublicDraftEntry[];
 };
 
+export type PublicDraftPreview = {
+  id: string;
+  title: string;
+  description: string | null;
+  updatedAt: string;
+  entries: Array<{
+    id: string;
+    position: number;
+    title: string | null;
+    body: string;
+  }>;
+};
+
 export type CreateDraftInput = {
   title: string;
   description?: string;

--- a/apps/web/app/utils/api.ts
+++ b/apps/web/app/utils/api.ts
@@ -3,6 +3,7 @@ import type {
   CreateDraftInput,
   PublicDraft,
   PublicDraftDetail,
+  PublicDraftPreview,
 } from '../types/drafts';
 import type { EntryInput, PublicEntry } from '../types/entries';
 
@@ -105,6 +106,11 @@ export function createDraftsApiClient(
     },
     getDraft(draftId: string) {
       return requestJson<PublicDraftDetail>(fetcher, baseUrl, `/drafts/${draftId}`, {
+        headers: createAuthHeaders(getAccessToken),
+      });
+    },
+    getDraftPreview(draftId: string) {
+      return requestJson<PublicDraftPreview>(fetcher, baseUrl, `/drafts/${draftId}/preview`, {
         headers: createAuthHeaders(getAccessToken),
       });
     },


### PR DESCRIPTION
## 요약

초안 상세 화면에서 실제 preview로 이동할 수 있도록 draft preview API와 프론트 reading 화면을 연결했습니다. 정적 시안으로 남아 있던 preview를 실제 draft 데이터 기반 흐름으로 바꾸면서 MVP의 `write -> archive -> draft -> preview` 루프를 코드로 완성했습니다.

## 변경 내용

- `apps/api`에 `GET /drafts/:id/preview` 계약과 preview 응답 타입을 추가했습니다.
- draft ownership, 존재하지 않는 draft, preview 응답 구조를 서비스 테스트와 e2e 테스트로 검증했습니다.
- `apps/web`에 `useDraftPreview` composable과 preview 타입을 추가해 preview 상태를 별도 로딩/오류 흐름으로 분리했습니다.
- `apps/web/app/pages/app/drafts/preview.vue`를 실제 API 기반 reading 화면으로 교체하고 문단 분리, empty/error/auth 상태를 연결했습니다.
- draft detail 화면에 preview 진입 링크를 추가하고 `WORKLOG.md`에 이번 단계 완료와 다음 액션을 기록했습니다.

## 왜 이 변경이 필요한가

Draft Organization 범위의 add / reorder / remove가 끝난 뒤에는 사용자가 초안을 한 권의 시작처럼 읽어볼 수 있어야 MVP의 감정적 proof point가 성립합니다. 이 변경은 `docs/product/MVP_SCOPE.md`와 `docs/engineering/IMPLEMENTATION_PHASES.md`의 Phase 6 Preview Experience를 실제 동작으로 연결하는 최소 end-to-end 범위입니다.

## 확인 방법

- `pnpm --filter @book-maker/api lint`
- `pnpm --filter @book-maker/api typecheck`
- `pnpm --filter @book-maker/api test`
- `pnpm --filter @book-maker/api test:e2e`
- `pnpm --filter @book-maker/api build`
- `pnpm --filter @book-maker/web lint`
- `pnpm --filter @book-maker/web typecheck`
- `pnpm --filter @book-maker/web test`
- `pnpm --filter @book-maker/web build`

## 관련 문서 / 이슈

- Closes: #31
- Related: #23, #25, #27, #29
- Docs: `WORKLOG.md`

## 체크리스트

- [x] 현재 MVP 방향과 충돌하지 않는다
- [x] 기존 문서/구조와 정합성을 확인했다
- [x] 필요한 경우 문서를 함께 수정했다
- [x] 필요한 경우 테스트를 추가했거나 테스트 불필요 사유를 판단했다
- [x] lint / typecheck / test / build 영향을 확인했다

## 비고

- web build에서 Nuxt `module-preload-polyfill` sourcemap 경고가 있었지만 빌드는 정상 완료됐습니다.
- preview route는 기존 정적 `preview.vue`를 유지하면서 query 기반 `draftId`로 실제 draft 데이터를 불러오는 방식으로 연결했습니다.
