### PR TITLE
feat: 랜딩 페이지 실제 구현

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -10,6 +10,34 @@
 
 ---
 
+## 2026-03-27 (Landing page implementation)
+
+### 완료
+
+- 이슈 `#33` 기준 `apps/web/app/pages/index.vue` 랜딩 페이지를 실제 Nuxt 화면으로 재구성
+- 현재 MVP 흐름에 맞춘 hero, 문제 설명, 사용 흐름, 구현 상태, CTA 섹션을 한글 카피 기준으로 정리
+- `landing-content.ts`로 랜딩 문구와 링크를 분리하고 Vitest로 핵심 구조/경로를 검증
+- 랜딩 전용 스타일을 보강해 prototype 방향을 유지하면서 현재 앱 라우트 기준 CTA를 실제 동작 경로로 연결
+
+### 현재 상태
+
+- 사용자는 랜딩에서 제품 메시지와 현재 구현된 MVP 흐름을 한눈에 이해하고, 바로 기록/아카이브/초안 화면으로 진입할 수 있다
+- `안녕, 나의 바다`의 public-facing 첫 화면이 정적 시안이 아니라 실제 앱 상태와 맞는 Nuxt 화면으로 연결되었다
+- MVP 핵심 화면 범위는 구현되었고, 남은 후속 작업은 polish와 핵심 E2E 보강 쪽에 가깝다
+
+### 다음 액션
+
+1. preview와 landing을 포함한 핵심 사용자 흐름 E2E 시나리오를 설계하고 최소 smoke 범위를 추가한다
+2. 랜딩과 app 사이 전환에서 copy / spacing / CTA 우선순위를 필요한 범위만 다듬는다
+3. PR 품질 게이트 기준으로 web build 경고와 향후 CI 연동 범위를 점검한다
+
+### 메모
+
+- 검증은 `pnpm --filter @book-maker/web lint`, `typecheck`, `test`, `build` 기준으로 확인
+- web build는 Nuxt `module-preload-polyfill` sourcemap 경고가 있었지만 빌드는 정상 완료됐다
+
+---
+
 ## 2026-03-27 (Draft preview flow)
 
 ### 완료

--- a/apps/web/app/assets/css/main.css
+++ b/apps/web/app/assets/css/main.css
@@ -262,6 +262,37 @@ textarea {
   margin-top: 44px;
 }
 
+.landing-hero {
+  padding-bottom: 112px;
+}
+
+.landing-hero-grid {
+  align-items: stretch;
+}
+
+.landing-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.landing-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 28px;
+}
+
+.landing-meta-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--line-strong);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 /* Paper panel (hero 우측) */
 .paper-panel {
   background: var(--surface);
@@ -274,6 +305,10 @@ textarea {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+}
+
+.landing-sheet {
+  gap: 32px;
 }
 
 .sheet-kicker {
@@ -311,6 +346,39 @@ textarea {
   color: var(--text-faint);
 }
 
+.landing-sheet-list {
+  display: grid;
+  gap: 12px;
+}
+
+.landing-sheet-link {
+  display: grid;
+  gap: 4px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  background: var(--surface-low);
+  transition:
+    background 120ms,
+    border-color 120ms;
+}
+
+.landing-sheet-link:hover {
+  background: var(--surface-mid);
+  border-color: var(--line-strong);
+}
+
+.landing-sheet-label {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.landing-sheet-copy {
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
 /* Sections */
 .section {
   padding: 120px 0;
@@ -346,6 +414,17 @@ textarea {
   margin-top: 14px;
 }
 
+.landing-intro-grid {
+  align-items: center;
+}
+
+.landing-problem-card {
+  padding: 36px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow);
+}
+
 /* Feature grid */
 .feature-grid {
   display: grid;
@@ -371,6 +450,99 @@ textarea {
   font-size: 14px;
   color: var(--text-muted);
   line-height: 1.78;
+}
+
+.landing-feature-grid {
+  margin-top: 64px;
+}
+
+.landing-feature-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.landing-inline-link {
+  margin-top: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.landing-inline-link:hover {
+  opacity: 0.76;
+}
+
+.landing-proof-section {
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.landing-proof-header {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 48px;
+  align-items: end;
+}
+
+.landing-proof-copy {
+  max-width: none;
+}
+
+.landing-proof-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  margin-top: 48px;
+}
+
+.landing-proof-card {
+  min-height: 220px;
+  padding: 28px 24px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+}
+
+.landing-proof-kicker {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  margin-bottom: 12px;
+}
+
+.landing-proof-card h3 {
+  font-size: 18px;
+  line-height: 1.45;
+  letter-spacing: -0.02em;
+}
+
+.landing-proof-card p {
+  margin-top: 14px;
+  font-size: 14px;
+  color: var(--text-muted);
+  line-height: 1.78;
+}
+
+.landing-cta-band {
+  margin-top: 0;
+}
+
+.landing-cta-inner {
+  max-width: 560px;
+}
+
+.landing-cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.landing-ghost-inv {
+  border-color: rgba(243, 240, 234, 0.28);
+  color: rgba(243, 240, 234, 0.88);
 }
 
 /* CTA band */
@@ -1307,12 +1479,14 @@ textarea {
 
 @media (max-width: 1024px) {
   .hero-grid,
-  .two-col {
+  .two-col,
+  .landing-proof-header {
     grid-template-columns: 1fr;
     gap: 48px;
   }
 
-  .feature-grid {
+  .feature-grid,
+  .landing-proof-grid {
     grid-template-columns: repeat(2, 1fr);
   }
 
@@ -1361,8 +1535,17 @@ textarea {
     min-height: 360px;
   }
 
+  .landing-problem-card,
+  .landing-proof-card {
+    padding: 24px 20px;
+  }
+
   .cta-band {
     padding: 64px 36px;
+  }
+
+  .landing-proof-grid {
+    grid-template-columns: 1fr;
   }
 
   .page-header {

--- a/apps/web/app/pages/index.vue
+++ b/apps/web/app/pages/index.vue
@@ -1,53 +1,82 @@
+<script setup lang="ts">
+import {
+  LANDING_FLOW_STEPS,
+  LANDING_LIVE_LINKS,
+  LANDING_PROOF_POINTS,
+} from '../utils/landing-content';
+</script>
+
 <template>
   <main>
-    <section class="hero">
-      <div class="container hero-grid">
-        <div>
+    <section class="hero landing-hero">
+      <div class="container hero-grid landing-hero-grid">
+        <div class="landing-copy">
           <span class="eyebrow">안녕, 나의 바다</span>
-          <h1 class="display">모든 안녕이<br />머무는 곳.</h1>
+          <h1 class="display">흩어진 글이<br />한 권이 되기까지</h1>
           <p class="lede">
-            짧게 남긴 장면과 마음을 차곡차곡 쌓아 두세요. 안녕, 나의 바다는 그 기록이 한 권의
-            흐름으로 자라나는 과정을 보여줍니다.
+            짧은 기록을 쌓아 두세요. 안녕, 나의 바다는 그 조각들이 아카이브와 초안을 거쳐 책처럼
+            읽히는 흐름으로 자라나는 과정을 보여줍니다.
           </p>
+
           <div class="actions">
-            <NuxtLink class="button-primary" to="/app/write">지금 기록하기</NuxtLink>
-            <NuxtLink class="button-ghost" to="/app/archive">아카이브 보기</NuxtLink>
+            <NuxtLink class="button-primary" to="/app/write">기록 시작하기</NuxtLink>
+            <NuxtLink class="button-ghost" to="/app/drafts">
+              초안 흐름 보기
+            </NuxtLink>
+          </div>
+
+          <div class="landing-meta-row">
+            <span class="landing-meta-pill">private-first writing product</span>
+            <span class="landing-meta-pill">responsive web first</span>
+            <span class="landing-meta-pill">MVP 구현 진행 중</span>
           </div>
         </div>
 
-        <div class="paper-panel hero-sheet">
+        <div class="paper-panel hero-sheet landing-sheet">
           <div class="sheet-kicker">
-            <span>2026.03.18</span>
-            <span class="dot-status">자동 저장됨</span>
+            <span>지금 할 수 있는 흐름</span>
+            <span class="dot-status">초안 미리보기 연결됨</span>
           </div>
+
           <div>
-            <h2 class="sheet-title">창가에<br />남은 빛</h2>
+            <h2 class="sheet-title">짧은 기록이<br />원고의 시작이 됩니다</h2>
             <p class="sheet-copy">
-              저녁빛이 식탁 위를 지나가던 순간은 생각보다 오래 남았다. 사라지는 것은 늘 빠르지만,
-              사라지기 직전의 장면은 이상하게 더 선명해진다.
+              기록을 남기고, 아카이브에서 다시 꺼내고, 초안으로 묶은 뒤, 읽기 화면에서 한 권의
+              시작처럼 확인해 보세요. 아직 출간 도구는 없지만, 지금 가장 중요한 루프는 이미
+              움직이고 있습니다.
             </p>
           </div>
-          <div class="sheet-footer">
-            <span>124자</span>
-            <span>나만 볼 수 있습니다</span>
+
+          <div class="landing-sheet-list">
+            <NuxtLink
+              v-for="link in LANDING_LIVE_LINKS"
+              :key="link.to"
+              class="landing-sheet-link"
+              :to="link.to"
+            >
+              <span class="landing-sheet-label">{{ link.label }}</span>
+              <span class="landing-sheet-copy">{{ link.copy }}</span>
+            </NuxtLink>
           </div>
         </div>
       </div>
     </section>
 
     <section class="section section-muted">
-      <div class="container two-col">
+      <div class="container two-col landing-intro-grid">
         <div>
-          <span class="eyebrow">문제</span>
-          <h2 class="section-title">글은 많이 썼는데,<br />원고는 없습니다.</h2>
+          <span class="eyebrow">왜 필요한가</span>
+          <h2 class="section-title">글은 남겼지만,<br />원고는 남지 않았습니다.</h2>
         </div>
-        <div>
+
+        <div class="landing-problem-card">
           <p class="section-copy">
-            SNS, 메모앱, 노트북에 흩어진 글들은 시간이 지나면 사라지거나 잊힙니다.
+            SNS에 올린 문장은 쉽게 흘러가고, 메모앱에 남긴 기록은 쌓여도 몸을 갖추지 못합니다.
+            많이 썼는데도 한 권은 시작되지 않은 것처럼 느껴지는 이유입니다.
           </p>
           <p class="section-copy">
-            안녕, 나의 바다는 짧은 기록을 잃지 않고 쌓아 두고, 그것을 한 권의 흐름으로 묶는
-            공간입니다.
+            안녕, 나의 바다는 짧은 기록을 잃지 않고 모아 두고, 서로 닿는 글을 초안으로 묶어,
+            실제로 읽어볼 수 있는 흐름까지 연결하는 공간입니다.
           </p>
         </div>
       </div>
@@ -56,39 +85,67 @@
     <section class="section">
       <div class="container">
         <span class="eyebrow">사용 흐름</span>
-        <h2 class="section-title">기록하고 쌓고<br />묶어서 읽습니다.</h2>
+        <h2 class="section-title">기록하고, 쌓고,<br />묶어서 읽어봅니다.</h2>
 
-        <div class="feature-grid">
-          <div class="feature-item">
-            <span class="eyebrow">01</span>
-            <h3>짧게 기록하기</h3>
-            <p>한 문장, 한 장면이면 충분합니다. 제목 없이 시작해도 됩니다.</p>
+        <div class="feature-grid landing-feature-grid">
+          <article
+            v-for="step in LANDING_FLOW_STEPS"
+            :key="step.number"
+            class="feature-item landing-feature-item"
+          >
+            <span class="eyebrow">{{ step.number }}</span>
+            <h3>{{ step.title }}</h3>
+            <p>{{ step.copy }}</p>
+            <NuxtLink class="landing-inline-link" :to="step.to">{{ step.cta }}</NuxtLink>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section landing-proof-section">
+      <div class="container">
+        <div class="landing-proof-header">
+          <div>
+            <span class="eyebrow">지금 구현된 것</span>
+            <h2 class="section-title">문서가 아니라 실제 화면으로 이어진 흐름입니다.</h2>
           </div>
-          <div class="feature-item">
-            <span class="eyebrow">02</span>
-            <h3>아카이브에 쌓기</h3>
-            <p>기록은 날짜 순으로 모입니다. 흘러가지 않고 내 공간에 남습니다.</p>
-          </div>
-          <div class="feature-item">
-            <span class="eyebrow">03</span>
-            <h3>초안으로 묶기</h3>
-            <p>닿는 글을 골라 순서를 정합니다. 흩어진 기록이 하나의 흐름이 됩니다.</p>
-          </div>
-          <div class="feature-item">
-            <span class="eyebrow">04</span>
-            <h3>책처럼 읽기</h3>
-            <p>편집 화면을 벗어나 읽기 모드에서 한 권처럼 읽어 봅니다.</p>
-          </div>
+          <p class="section-copy landing-proof-copy">
+            현재 MVP는 기록 작성, 아카이브, 초안 정리, 초안 미리보기까지 연결되어 있습니다. 랜딩은
+            그 현재 상태를 과장 없이 보여주는 입구여야 합니다.
+          </p>
         </div>
 
-        <div class="cta-band">
-          <div class="cta-band-inner">
-            <span class="cta-band-label">조용한 글쓰기 공간</span>
-            <h3 class="cta-band-title">UI는 조용하게.<br />글은 앞으로.</h3>
+        <div class="landing-proof-grid">
+          <article
+            v-for="point in LANDING_PROOF_POINTS"
+            :key="point.title"
+            class="landing-proof-card"
+          >
+            <span class="landing-proof-kicker">{{ point.kicker }}</span>
+            <h3>{{ point.title }}</h3>
+            <p>{{ point.copy }}</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="cta-band landing-cta-band">
+          <div class="cta-band-inner landing-cta-inner">
+            <span class="cta-band-label">조용한 제품 소개</span>
+            <h3 class="cta-band-title">지금은 크게 설명하기보다,<br />조용히 시작할 수 있어야 합니다.</h3>
             <p class="cta-band-copy">
-              군더더기 없는 화면에서 글을 쓰고, 내가 쓴 것이 어떻게 읽히는지 확인할 수 있습니다.
+              기록은 짧게 시작하고, 초안은 천천히 모으고, 미리보기에서 한 권의 감각을 확인합니다.
+              안녕, 나의 바다는 그 첫 루프를 먼저 완성하는 중입니다.
             </p>
-            <NuxtLink class="button-inv" to="/app/write">지금 시작하기</NuxtLink>
+
+            <div class="landing-cta-actions">
+              <NuxtLink class="button-inv" to="/app/write">첫 기록 남기기</NuxtLink>
+              <NuxtLink class="button-ghost landing-ghost-inv" to="/app/drafts">
+                초안 둘러보기
+              </NuxtLink>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/app/utils/landing-content.spec.ts
+++ b/apps/web/app/utils/landing-content.spec.ts
@@ -1,0 +1,35 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+
+import {
+  LANDING_FLOW_STEPS,
+  LANDING_LIVE_LINKS,
+  LANDING_PROOF_POINTS,
+} from './landing-content';
+
+describe('landing content', () => {
+  it('describes the four MVP flow steps in order', () => {
+    expect(LANDING_FLOW_STEPS).toHaveLength(4);
+    expect(LANDING_FLOW_STEPS.map((step) => step.number)).toEqual(['01', '02', '03', '04']);
+  });
+
+  it('links only to currently available app routes', () => {
+    expect(LANDING_LIVE_LINKS.map((link) => link.to)).toEqual([
+      '/app/write',
+      '/app/archive',
+      '/app/drafts',
+    ]);
+  });
+
+  it('keeps proof points focused on the current MVP loop', () => {
+    expect(LANDING_PROOF_POINTS.map((point) => point.kicker)).toEqual([
+      'Write',
+      'Archive',
+      'Draft',
+      'Preview',
+    ]);
+  });
+});

--- a/apps/web/app/utils/landing-content.ts
+++ b/apps/web/app/utils/landing-content.ts
@@ -1,0 +1,71 @@
+export const LANDING_FLOW_STEPS = [
+  {
+    number: '01',
+    title: '짧게 기록하기',
+    copy: '제목 없이 시작해도 됩니다. 오늘 떠오른 장면과 마음을 빠르게 남깁니다.',
+    cta: '기록 화면으로',
+    to: '/app/write',
+  },
+  {
+    number: '02',
+    title: '아카이브에 쌓기',
+    copy: '흘러가지 않도록 내 기록을 다시 읽고, 날짜 흐름 안에서 이어 붙일 수 있습니다.',
+    cta: '아카이브 보기',
+    to: '/app/archive',
+  },
+  {
+    number: '03',
+    title: '초안으로 묶기',
+    copy: '서로 닿는 기록을 골라 순서를 정리하면, 흩어진 글이 하나의 초안이 됩니다.',
+    cta: '초안으로 이동',
+    to: '/app/drafts',
+  },
+  {
+    number: '04',
+    title: '책처럼 읽기',
+    copy: '편집 화면을 벗어나 읽기 모드에서 한 권의 시작처럼 흐름을 확인할 수 있습니다.',
+    cta: '초안에서 이어 보기',
+    to: '/app/drafts',
+  },
+] as const;
+
+export const LANDING_LIVE_LINKS = [
+  {
+    label: '기록하기',
+    copy: '짧은 글을 남기고 자동 저장 흐름을 확인합니다.',
+    to: '/app/write',
+  },
+  {
+    label: '아카이브',
+    copy: '쌓인 기록을 다시 찾고 상세로 열어 봅니다.',
+    to: '/app/archive',
+  },
+  {
+    label: '초안',
+    copy: '기록을 묶고 순서를 정리하며 초안을 다듬습니다.',
+    to: '/app/drafts',
+  },
+] as const;
+
+export const LANDING_PROOF_POINTS = [
+  {
+    kicker: 'Write',
+    title: '자동 저장까지 연결된 기록 화면',
+    copy: '짧은 기록을 남기고 같은 화면에서 저장 상태를 확인할 수 있습니다.',
+  },
+  {
+    kicker: 'Archive',
+    title: '다시 찾을 수 있는 개인 아카이브',
+    copy: '지난 기록을 목록과 상세 화면에서 다시 읽고 이어 쓸 수 있습니다.',
+  },
+  {
+    kicker: 'Draft',
+    title: '모으고 정리하는 초안 흐름',
+    copy: '기록을 초안에 담고 순서를 바꾸고 제외하면서 흐름을 다듬을 수 있습니다.',
+  },
+  {
+    kicker: 'Preview',
+    title: '읽기 모드로 확인하는 책의 시작',
+    copy: '초안 제목과 본문을 연속 읽기 화면에서 확인하며 감정적 proof point를 만듭니다.',
+  },
+] as const;


### PR DESCRIPTION
## 요약

정적 프로토타입으로 남아 있던 랜딩 페이지를 실제 Nuxt 화면으로 옮기고, 현재 구현된 MVP 흐름과 앱 진입 CTA를 한글 기준 카피로 다시 구성했습니다.

## 변경 내용

- `apps/web/app/pages/index.vue`를 실제 랜딩 화면으로 재구성해 hero, 문제 설명, 사용 흐름, 구현 상태, CTA 섹션을 연결했습니다
- `apps/web/app/utils/landing-content.ts`로 랜딩 문구와 실제 앱 라우트 링크를 분리해 화면 구조와 콘텐츠를 명시적으로 관리하도록 정리했습니다
- `apps/web/app/assets/css/main.css`에 랜딩 전용 레이아웃과 반응형 스타일을 보강해 prototype 방향을 실제 앱 스타일로 옮겼습니다
- `apps/web/app/utils/landing-content.spec.ts`를 추가해 MVP 흐름 순서와 랜딩 링크 구성이 현재 동작 가능한 경로만 가리키는지 검증했습니다
- `WORKLOG.md`에 이번 랜딩 구현 작업과 검증 결과를 기록했습니다

## 왜 이 변경이 필요한가

- `docs/engineering/IMPLEMENTATION_PHASES.md`의 Phase 7 `Landing And Product Polish`에 맞는 현재 단계 작업입니다
- preview까지 연결된 MVP 핵심 루프를 외부에서 한눈에 이해할 수 있는 실제 제품 첫 화면이 필요했습니다
- 정적 시안에 머무르지 않고 현재 동작 가능한 앱 경로만 노출해야 제품 메시지와 구현 상태가 어긋나지 않습니다

## 확인 방법

- `pnpm --filter @book-maker/web lint`
- `pnpm --filter @book-maker/web typecheck`
- `pnpm --filter @book-maker/web test`
- `pnpm --filter @book-maker/web build`

## 관련 문서 / 이슈

- Closes: #33
- Related:
- Docs: `WORKLOG.md`

## 체크리스트

- [x] 현재 MVP 방향과 충돌하지 않는다
- [x] 기존 문서/구조와 정합성을 확인했다
- [x] 필요한 경우 문서를 함께 수정했다
- [x] 필요한 경우 테스트를 추가했거나 테스트 불필요 사유를 판단했다
- [x] lint / typecheck / test / build 영향을 확인했다

## 비고

- web build에서 Nuxt `module-preload-polyfill` sourcemap 경고가 있었지만 빌드는 정상 완료됐습니다
