### PR TITLE
chore: Playwright smoke e2e 기반 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,20 @@ jobs:
 
       - name: API e2e test
         run: pnpm test:api:e2e
+
+      - name: Start local infra for web smoke e2e
+        run: docker compose up -d postgres redis
+
+      - name: Wait for postgres and redis health
+        run: |
+          for service in book-maker-postgres book-maker-redis; do
+            until [ "$(docker inspect -f '{{.State.Health.Status}}' "$service")" = "healthy" ]; do
+              sleep 2
+            done
+          done
+
+      - name: Install Playwright browser
+        run: pnpm --filter @book-maker/web exec playwright install --with-deps chromium
+
+      - name: Web smoke e2e test
+        run: pnpm test:web:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ node_modules/
 dist/
 coverage/
 .vite/
+apps/web/test-results/
+apps/web/playwright-report/
 
 # NestJS / TypeScript
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -94,5 +94,6 @@
 - `pnpm lint`
 - `pnpm lint:fix`
 - `pnpm typecheck`
+- `pnpm test:web:e2e`
 - `pnpm format`
 - `pnpm format:check`

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -10,6 +10,34 @@
 
 ---
 
+## 2026-03-27 (Playwright smoke e2e baseline)
+
+### 완료
+
+- 이슈 `#35` 기준 `apps/web`에 Playwright baseline과 핵심 사용자 흐름 smoke 시나리오를 추가
+- 랜딩 CTA에서 시작해 `write -> archive -> draft -> preview`로 이어지는 최소 E2E를 실제 UI 기준으로 연결
+- smoke 시나리오가 덜 brittle하게 동작하도록 랜딩, write, draft 화면에 최소 테스트 훅을 추가
+- 루트 스크립트와 CI 워크플로에 web smoke e2e 실행 경로를 보강
+
+### 현재 상태
+
+- MVP 핵심 루프는 unit/integration 수준을 넘어 실제 브라우저 흐름으로도 회귀를 확인할 수 있는 baseline이 생겼다
+- PR 품질 게이트에서 backend e2e와 별도로 frontend 핵심 사용자 흐름 smoke를 연결할 수 있는 구조가 마련되었다
+- 남은 후속 작업은 smoke 범위를 넓히기보다 flaky 포인트를 줄이고 필요한 최소 시나리오만 정제하는 쪽에 가깝다
+
+### 다음 액션
+
+1. smoke E2E를 실제 CI에서 안정적으로 반복 실행하면서 flaky 지점을 정리한다
+2. 필요하면 인증 만료 복구나 entry reorder 같은 고위험 흐름을 후속 smoke 시나리오로 분리한다
+3. landing과 preview 주변 polish는 회귀 보호 범위를 유지한 채 필요한 수준만 다듬는다
+
+### 메모
+
+- 검증은 `pnpm --filter @book-maker/web lint`, `typecheck`, `test`, `build`, `test:e2e`를 기준으로 확인
+- web smoke e2e는 PostgreSQL / Redis가 켜진 상태에서 API와 web 서버를 함께 띄우는 구조를 사용한다
+
+---
+
 ## 2026-03-27 (Landing page implementation)
 
 ### 완료

--- a/apps/web/app/pages/app/drafts.vue
+++ b/apps/web/app/pages/app/drafts.vue
@@ -9,6 +9,7 @@ import { formatEntryDateTime } from '../../utils/entry-format';
 definePageMeta({ layout: 'app' });
 
 const runtimeConfig = useRuntimeConfig();
+const route = useRoute();
 
 const {
   hydrated,
@@ -42,6 +43,7 @@ const createForm = reactive({
 const draftCountLabel = computed(() =>
   listState.value === 'loaded' ? `초안 ${drafts.value.length}개` : '초안 흐름을 준비하는 중',
 );
+const isDraftListRoute = computed(() => route.path === '/app/drafts');
 
 watch(
   [hydrated, isAuthenticated],
@@ -90,7 +92,7 @@ function formatStatus(status: 'active' | 'archived') {
 </script>
 
 <template>
-  <main class="app-grid">
+  <main v-if="isDraftListRoute" class="app-grid">
     <aside class="sidebar">
       <div>
         <div class="sidebar-badge">초안</div>
@@ -156,7 +158,12 @@ function formatStatus(status: 'active' | 'archived') {
           <form class="draft-create-form" @submit.prevent="submitDraftCreate">
             <label class="draft-create-field">
               <span>초안 제목</span>
-              <input v-model="createForm.title" maxlength="255" placeholder="예: 고요가 머무는 자리" />
+              <input
+                v-model="createForm.title"
+                data-testid="draft-create-title-input"
+                maxlength="255"
+                placeholder="예: 고요가 머무는 자리"
+              />
             </label>
 
             <label class="draft-create-field">
@@ -176,6 +183,7 @@ function formatStatus(status: 'active' | 'archived') {
             <div class="draft-create-actions">
               <button
                 class="button-primary"
+                data-testid="draft-create-submit"
                 type="submit"
                 :disabled="createState === 'submitting' || createForm.title.trim().length === 0"
               >
@@ -234,4 +242,5 @@ function formatStatus(status: 'active' | 'archived') {
       </div>
     </section>
   </main>
+  <NuxtPage v-else />
 </template>

--- a/apps/web/app/pages/app/drafts/[id].vue
+++ b/apps/web/app/pages/app/drafts/[id].vue
@@ -316,6 +316,7 @@ function handleEntrySelectionChange(entryId: string, event: Event) {
           <div class="draft-create-actions">
             <NuxtLink
               class="button-primary"
+              data-testid="draft-open-preview"
               :to="`/app/drafts/preview?draftId=${draftId}`"
             >
               책처럼 읽어보기
@@ -369,6 +370,7 @@ function handleEntrySelectionChange(entryId: string, event: Event) {
             <div class="draft-create-actions">
               <button
                 class="button-primary"
+                data-testid="draft-attach-submit"
                 type="button"
                 :disabled="!canSubmitEntryAttach"
                 @click="submitEntryAttach"

--- a/apps/web/app/pages/app/write.vue
+++ b/apps/web/app/pages/app/write.vue
@@ -260,12 +260,17 @@ function formatTime(value: string) {
             </button>
           </div>
 
-          <form class="writer-auth-form" @submit.prevent="submitAuth">
+          <form
+            class="writer-auth-form"
+            data-testid="auth-form"
+            @submit.prevent="submitAuth"
+          >
             <label v-if="authMode === 'signup'" class="writer-auth-field">
               <span>이름</span>
               <input
                 v-model="authForm.displayName"
                 autocomplete="name"
+                data-testid="auth-display-name-input"
                 placeholder="기록에 남길 이름"
                 type="text"
               />
@@ -276,6 +281,7 @@ function formatTime(value: string) {
               <input
                 v-model="authForm.email"
                 autocomplete="email"
+                data-testid="auth-email-input"
                 placeholder="you@example.com"
                 type="email"
               />
@@ -286,6 +292,7 @@ function formatTime(value: string) {
               <input
                 v-model="authForm.password"
                 autocomplete="current-password"
+                data-testid="auth-password-input"
                 placeholder="8자 이상"
                 type="password"
               />
@@ -295,7 +302,12 @@ function formatTime(value: string) {
               {{ authError }}
             </p>
 
-            <button class="button-primary" type="submit" :disabled="authPending">
+            <button
+              class="button-primary"
+              data-testid="auth-submit-button"
+              type="submit"
+              :disabled="authPending"
+            >
               {{
                 authPending
                   ? '세션 준비 중...'
@@ -308,10 +320,16 @@ function formatTime(value: string) {
         </article>
       </div>
 
-      <article v-else class="writer-sheet">
+      <article v-else class="writer-sheet" data-testid="writer-sheet">
         <div class="writer-topline">
           <span class="writer-meta">{{ entryDateLabel }}</span>
-          <span class="dot-status" :data-tone="saveState">{{ saveStatusLabel }}</span>
+          <span
+            class="dot-status"
+            data-testid="entry-save-status"
+            :data-tone="saveState"
+          >
+            {{ saveStatusLabel }}
+          </span>
         </div>
 
         <p v-if="entryLoadPending" class="writer-alert">기존 기록을 불러오는 중입니다.</p>
@@ -336,6 +354,7 @@ function formatTime(value: string) {
         <input
           v-model="title"
           class="writer-title"
+          data-testid="entry-title-input"
           placeholder="제목 (선택)"
           spellcheck="false"
         />
@@ -343,6 +362,7 @@ function formatTime(value: string) {
         <textarea
           v-model="body"
           class="writer-body"
+          data-testid="entry-body-input"
           placeholder="오늘의 장면이나 생각을 남겨 보세요."
           rows="14"
         />
@@ -359,7 +379,11 @@ function formatTime(value: string) {
         </div>
 
         <div v-if="savedArchiveLink" class="writer-links">
-          <NuxtLink class="button-ghost" :to="savedArchiveLink.archive">
+          <NuxtLink
+            class="button-ghost"
+            data-testid="entry-archive-link"
+            :to="savedArchiveLink.archive"
+          >
             아카이브에서 확인
           </NuxtLink>
           <NuxtLink class="button-ghost" :to="savedArchiveLink.detail">

--- a/apps/web/app/pages/index.vue
+++ b/apps/web/app/pages/index.vue
@@ -19,7 +19,13 @@ import {
           </p>
 
           <div class="actions">
-            <NuxtLink class="button-primary" to="/app/write">기록 시작하기</NuxtLink>
+            <NuxtLink
+              class="button-primary"
+              data-testid="landing-start-writing"
+              to="/app/write"
+            >
+              기록 시작하기
+            </NuxtLink>
             <NuxtLink class="button-ghost" to="/app/drafts">
               초안 흐름 보기
             </NuxtLink>

--- a/apps/web/e2e/core-loop.spec.ts
+++ b/apps/web/e2e/core-loop.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test';
+
+test('landing에서 시작해 write -> archive -> draft -> preview 핵심 루프를 확인한다', async ({
+  page,
+}) => {
+  const uniqueSuffix = `${Date.now()}`;
+  const email = `smoke-${uniqueSuffix}@example.com`;
+  const password = 'password-1234';
+  const displayName = `연결 테스트 ${uniqueSuffix}`;
+  const entryTitle = `새벽 기록 ${uniqueSuffix}`;
+  const entryBody = [
+    '바다는 아직 말이 없었고, 창문에는 이른 물빛이 남아 있었다.',
+    '짧게 남긴 문장이 오늘의 원고 첫 장면이 되는지 확인하고 싶었다.',
+  ].join('\n\n');
+  const draftTitle = `새벽 초안 ${uniqueSuffix}`;
+
+  await page.goto('/');
+  await page.getByTestId('landing-start-writing').click();
+
+  await expect(page).toHaveURL(/\/app\/write$/);
+  await page.getByTestId('auth-display-name-input').fill(displayName);
+  await page.getByTestId('auth-email-input').fill(email);
+  await page.getByTestId('auth-password-input').fill(password);
+  await page.getByTestId('auth-submit-button').click();
+
+  await expect(page.getByTestId('writer-sheet')).toBeVisible();
+
+  await page.getByTestId('entry-title-input').fill(entryTitle);
+  await page.getByTestId('entry-body-input').fill(entryBody);
+
+  await expect(page.getByTestId('entry-save-status')).toHaveText('저장됨', {
+    timeout: 15_000,
+  });
+
+  await page.getByTestId('entry-archive-link').click();
+
+  await expect(page).toHaveURL(/\/app\/archive/);
+  await expect(page.getByRole('link', { name: entryTitle })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  await page.goto('/app/drafts');
+  await page.getByTestId('draft-create-title-input').fill(draftTitle);
+  await page.getByTestId('draft-create-submit').click();
+
+  const draftDetailTitle = page.locator('.draft-title-display', { hasText: draftTitle });
+  const landedOnDetail = await draftDetailTitle
+    .waitFor({ state: 'visible', timeout: 5_000 })
+    .then(() => true)
+    .catch(() => false);
+
+  if (!landedOnDetail) {
+    const createdDraftLink = page.getByRole('link', { name: draftTitle });
+    await expect(createdDraftLink).toBeVisible({ timeout: 15_000 });
+    await createdDraftLink.click();
+  }
+
+  await expect(draftDetailTitle).toBeVisible({ timeout: 15_000 });
+  await expect(page).toHaveURL(/\/app\/drafts\/[^/?]+$/);
+
+  const availableEntryCheckbox = page.getByRole('checkbox', {
+    name: new RegExp(entryTitle),
+  });
+  await expect(availableEntryCheckbox).toBeVisible({ timeout: 15_000 });
+  await availableEntryCheckbox.check();
+  await page.getByTestId('draft-attach-submit').click();
+
+  await expect(page.locator('.sequence-item', { hasText: entryTitle })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  await page.getByTestId('draft-open-preview').click();
+
+  await expect(page).toHaveURL(/\/app\/drafts\/preview\?draftId=/);
+  await expect(page.getByRole('heading', { name: draftTitle })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByText(entryBody.split('\n\n')[0] ?? '')).toBeVisible();
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "typecheck": "nuxt typecheck"
   },
   "dependencies": {
@@ -19,6 +20,7 @@
     "vue-router": "^5.0.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@types/node": "^22.19.15",
     "vitest": "^4.1.1",
     "vue-tsc": "^3.2.6"

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,66 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const apiBaseUrl = 'http://127.0.0.1:4000';
+const webBaseUrl = 'http://127.0.0.1:3000';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: webBaseUrl,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: [
+    {
+      command:
+        'pnpm --dir ../.. db:migrate:api && pnpm --dir ../.. --filter @book-maker/api start:dev',
+      url: `${apiBaseUrl}/api/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        NODE_ENV: 'development',
+        API_PORT: '4000',
+        API_PREFIX: 'api',
+        POSTGRES_HOST: process.env.POSTGRES_HOST ?? '127.0.0.1',
+        POSTGRES_PORT: process.env.POSTGRES_PORT ?? '5432',
+        POSTGRES_DB: process.env.POSTGRES_DB ?? 'book_maker',
+        POSTGRES_USER: process.env.POSTGRES_USER ?? 'book_maker',
+        POSTGRES_PASSWORD: process.env.POSTGRES_PASSWORD ?? 'book_maker',
+        POSTGRES_CONNECT_ON_BOOTSTRAP: 'true',
+        REDIS_HOST: process.env.REDIS_HOST ?? '127.0.0.1',
+        REDIS_PORT: process.env.REDIS_PORT ?? '6379',
+        REDIS_DB: process.env.REDIS_DB ?? '0',
+        REDIS_CONNECT_ON_BOOTSTRAP: 'true',
+        AUTH_ACCESS_TOKEN_SECRET:
+          process.env.AUTH_ACCESS_TOKEN_SECRET ?? 'book-maker-access-secret',
+        AUTH_ACCESS_TOKEN_EXPIRES_IN:
+          process.env.AUTH_ACCESS_TOKEN_EXPIRES_IN ?? '15m',
+        AUTH_REFRESH_TOKEN_SECRET:
+          process.env.AUTH_REFRESH_TOKEN_SECRET ?? 'book-maker-refresh-secret',
+        AUTH_REFRESH_TOKEN_EXPIRES_IN:
+          process.env.AUTH_REFRESH_TOKEN_EXPIRES_IN ?? '14d',
+        AUTH_REFRESH_SESSION_PREFIX:
+          process.env.AUTH_REFRESH_SESSION_PREFIX ?? 'auth:refresh',
+      },
+    },
+    {
+      command: 'pnpm dev --host 127.0.0.1 --port 3000',
+      url: webBaseUrl,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        NUXT_PUBLIC_API_BASE: `${apiBaseUrl}/api`,
+      },
+    },
+  ],
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['e2e/**/*', 'node_modules/**/*', '.nuxt/**/*', '.output/**/*'],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint:web": "pnpm --filter @book-maker/web lint",
     "lint:fix:web": "pnpm --filter @book-maker/web lint:fix",
     "test:web": "pnpm --filter @book-maker/web test",
+    "test:web:e2e": "pnpm --filter @book-maker/web test:e2e",
     "typecheck:web": "pnpm --filter @book-maker/web typecheck",
     "dev:api": "pnpm --filter @book-maker/api start:dev",
     "build:api": "pnpm --filter @book-maker/api build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
         specifier: ^5.0.3
         version: 5.0.4(@vue/compiler-sfc@3.5.30)(vue@3.5.30(typescript@5.9.3))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@types/node':
         specifier: ^22.19.15
         version: 22.19.15
@@ -1615,6 +1618,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -3514,6 +3522,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4644,6 +4657,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -7575,6 +7598,10 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
   '@polka/url@1.0.0-next.29': {}
 
   '@poppinss/colors@4.1.6':
@@ -9550,6 +9577,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -11081,6 +11111,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
## 요약

Playwright 기반 web smoke E2E baseline을 추가해 `write -> archive -> draft -> preview` 핵심 루프를 실제 브라우저 흐름으로 검증할 수 있게 했고, 그 과정에서 드러난 drafts 하위 라우트 렌더링 문제도 함께 바로잡았습니다.

## 변경 내용

- `apps/web/playwright.config.ts`, `apps/web/e2e/core-loop.spec.ts`, `apps/web/vitest.config.ts`를 추가해 Playwright smoke E2E baseline과 Vitest 테스트 경계를 정리했습니다
- 루트와 web 패키지 스크립트, lockfile, `.gitignore`를 업데이트해 `pnpm test:web:e2e` 실행 경로와 Playwright 산출물 제외 규칙을 추가했습니다
- `apps/web/app/pages/index.vue`, `apps/web/app/pages/app/write.vue`, `apps/web/app/pages/app/drafts/[id].vue`에 최소 `data-testid`를 추가해 smoke 시나리오를 안정적으로 제어할 수 있게 했습니다
- `apps/web/app/pages/app/drafts.vue`가 하위 라우트에서 `NuxtPage`를 렌더링하도록 수정해 draft detail/preview가 리스트 화면에 가려지지 않게 했습니다
- `.github/workflows/ci.yml`, `README.md`, `WORKLOG.md`를 갱신해 CI 실행 경로와 작업 기록을 동기화했습니다

## 왜 이 변경이 필요한가

- `docs/engineering/TEST_STRATEGY.md`에서 정의한 MVP 핵심 루프 회귀를 실제 브라우저 수준에서 최소 smoke로 보호해야 했습니다
- `docs/engineering/DEVOPS_CICD_PLAN.md`의 PR 품질 게이트 방향에 맞춰 web smoke E2E를 CI에서 돌릴 수 있는 baseline이 필요했습니다
- smoke를 추가하는 과정에서 드러난 drafts nested route 렌더링 문제는 실제 사용자 흐름에도 영향을 주는 버그라 함께 수정하는 편이 맞았습니다

## 확인 방법

- `pnpm --filter @book-maker/web lint`
- `pnpm --filter @book-maker/web typecheck`
- `pnpm --filter @book-maker/web test`
- `pnpm --filter @book-maker/web build`
- `pnpm test:web:e2e`

## 관련 문서 / 이슈

- Closes: #35
- Related:
- Docs: `README.md`, `WORKLOG.md`

## 체크리스트

- [x] 현재 MVP 방향과 충돌하지 않는다
- [x] 기존 문서/구조와 정합성을 확인했다
- [x] 필요한 경우 문서를 함께 수정했다
- [x] 필요한 경우 테스트를 추가했거나 테스트 불필요 사유를 판단했다
- [x] lint / typecheck / test / build 영향을 확인했다

## 비고

- `pnpm test:web:e2e`는 PostgreSQL / Redis가 떠 있는 상태에서 API와 web 서버를 함께 기동하는 구조입니다
- web build에서는 기존과 동일하게 Nuxt `module-preload-polyfill` sourcemap 경고가 있었지만 빌드는 정상 완료됐습니다
