### PR TITLE
test: 인증 만료 smoke e2e 추가

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -38,6 +38,33 @@
 
 ---
 
+## 2026-03-27 (Auth expiry smoke e2e)
+
+### 완료
+
+- 이슈 `#38` 기준 Playwright auth helper를 추가해 write 화면 회원가입과 local storage session 조작을 재사용 가능하게 정리
+- access token이 더 이상 유효하지 않을 때 autosave 요청이 401 이후 세션을 정리하고 로그인 화면으로 복귀하는 smoke 시나리오를 추가
+- 인증 만료 시 저장 요청이 무한 반복되지 않고 한 번만 발생하는지 브라우저 수준에서 함께 확인
+
+### 현재 상태
+
+- 핵심 루프 smoke 외에 인증 세션 단절 리스크도 브라우저 E2E로 회귀 보호 범위에 들어왔다
+- 현재 auth 구조는 silent refresh보다 세션 정리/로그인 재진입 흐름을 우선 검증하는 상태다
+- 남은 후속 작업은 CI에서 이 시나리오 실행 시간과 flaky 포인트를 관찰하며 필요한 범위만 다듬는 쪽이다
+
+### 다음 액션
+
+1. GitHub Actions에서 auth-expiry smoke까지 포함한 Playwright 실행 시간을 보고 retry나 step 분리를 필요한 수준만 검토한다
+2. auth/session 구조가 실제 refresh 흐름까지 확장되면 별도 smoke로 silent refresh 성공/실패 분기를 나눈다
+3. 고위험 회귀 구간은 현재처럼 최소 시나리오 중심으로만 점진 확장한다
+
+### 메모
+
+- 검증은 `pnpm --filter @book-maker/web lint`, `typecheck`, `pnpm test:web:e2e` 기준으로 확인한다
+- 이번 smoke는 현재 구현과 맞춰 `refresh 복구`가 아니라 `세션 정리 후 로그인 재진입` 흐름을 보호한다
+
+---
+
 ## 2026-03-27 (Playwright smoke e2e baseline)
 
 ### 완료

--- a/apps/web/e2e/auth-expiry.spec.ts
+++ b/apps/web/e2e/auth-expiry.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  overwriteStoredAccessToken,
+  readStoredAuthSession,
+  signupFromWritePage,
+} from './helpers/auth';
+
+test('autosave 중 access token이 유효하지 않으면 세션을 정리하고 로그인 화면으로 돌려보낸다', async ({
+  page,
+}) => {
+  const uniqueSuffix = `${Date.now()}`;
+  const saveRequestUrls: string[] = [];
+
+  page.on('request', (request) => {
+    if (
+      request.method() === 'POST' &&
+      request.url().endsWith('/api/entries')
+    ) {
+      saveRequestUrls.push(request.url());
+    }
+  });
+
+  await signupFromWritePage(page, {
+    displayName: `만료 테스트 ${uniqueSuffix}`,
+    email: `auth-expiry-${uniqueSuffix}@example.com`,
+    password: 'password-1234',
+  });
+
+  const initialSession = await readStoredAuthSession(page);
+  expect(initialSession?.refreshToken).toBeTruthy();
+
+  await overwriteStoredAccessToken(page, 'expired-access-token');
+  await page.reload();
+
+  await expect(page.getByTestId('writer-sheet')).toBeVisible();
+
+  await page.getByTestId('entry-body-input').fill(
+    '세션이 유효하지 않을 때 자동 저장이 반복 재시도 없이 멈추는지 확인합니다.',
+  );
+
+  await expect(page.getByTestId('auth-form')).toBeVisible({ timeout: 15_000 });
+  await expect(
+    page.getByRole('heading', {
+      name: '기록을 시작하려면 먼저 세션이 필요합니다.',
+    }),
+  ).toBeVisible();
+
+  await page.waitForTimeout(1_000);
+
+  expect(saveRequestUrls).toHaveLength(1);
+  await expect.poll(() => readStoredAuthSession(page)).toBeNull();
+});

--- a/apps/web/e2e/helpers/auth.ts
+++ b/apps/web/e2e/helpers/auth.ts
@@ -1,0 +1,68 @@
+import { expect, type Page } from '@playwright/test';
+
+const AUTH_SESSION_STORAGE_KEY = 'book-maker.auth-session';
+
+type SignupOptions = {
+  displayName: string;
+  email: string;
+  password: string;
+};
+
+type StoredAuthSession = {
+  accessToken: string;
+  refreshToken: string;
+  user: {
+    id: string;
+    email: string;
+    displayName: string;
+    createdAt: string;
+    updatedAt: string;
+  };
+};
+
+export async function signupFromWritePage(page: Page, options: SignupOptions) {
+  await page.goto('/app/write');
+
+  await expect(page).toHaveURL(/\/app\/write$/);
+  await page.getByTestId('auth-display-name-input').fill(options.displayName);
+  await page.getByTestId('auth-email-input').fill(options.email);
+  await page.getByTestId('auth-password-input').fill(options.password);
+  await page.getByTestId('auth-submit-button').click();
+
+  await expect(page.getByTestId('writer-sheet')).toBeVisible();
+}
+
+export async function readStoredAuthSession(page: Page) {
+  return page.evaluate<never, StoredAuthSession | null>((storageKey) => {
+    const rawValue = window.localStorage.getItem(storageKey);
+
+    if (!rawValue) {
+      return null;
+    }
+
+    return JSON.parse(rawValue) as StoredAuthSession;
+  }, AUTH_SESSION_STORAGE_KEY);
+}
+
+export async function overwriteStoredAccessToken(page: Page, accessToken: string) {
+  await page.evaluate(
+    ([storageKey, nextAccessToken]) => {
+      const rawValue = window.localStorage.getItem(storageKey);
+
+      if (!rawValue) {
+        throw new Error('Auth session is missing.');
+      }
+
+      const session = JSON.parse(rawValue) as StoredAuthSession;
+
+      window.localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          ...session,
+          accessToken: nextAccessToken,
+        }),
+      );
+    },
+    [AUTH_SESSION_STORAGE_KEY, accessToken] as const,
+  );
+}


### PR DESCRIPTION
## 요약

Playwright smoke 범위에 인증 세션 단절 회귀를 추가했습니다. write 화면에서 유효하지 않은 access token으로 autosave가 발생했을 때 세션이 정리되고 로그인 재진입 화면으로 복귀하는지, 그리고 저장 요청이 무한 재시도되지 않는지를 브라우저 수준에서 보호합니다.

## 변경 내용

- write 화면 회원가입과 local storage session 조작을 재사용할 수 있도록 Playwright auth helper 추가
- invalid access token 상태로 autosave를 유도해 `세션 정리 -> 로그인 화면 복귀`를 검증하는 auth-expiry smoke 시나리오 추가
- 인증 만료 시 저장 요청이 한 번만 발생하는지 함께 확인해 무한 재시도 회귀를 방지
- `WORKLOG.md`에 auth-expiry smoke 작업과 후속 관찰 포인트 기록

## 왜 이 변경이 필요한가

- `docs/engineering/TEST_STRATEGY.md`에서 인증 세션 단절은 별도 핵심 리스크로 정의돼 있습니다.
- 기존 smoke는 MVP 핵심 루프만 보호했고, access token 만료 후 write autosave가 어떤 상태 전이를 보이는지는 브라우저 E2E로 막혀 있지 않았습니다.
- 이번 변경으로 현재 auth 구조에 맞는 최소 시나리오를 추가해, 세션 만료 후 무한 재시도나 상태 꼬임 같은 회귀를 조기에 잡을 수 있습니다.

## 확인 방법

- `pnpm --filter @book-maker/web lint`
- `pnpm --filter @book-maker/web typecheck`
- `pnpm test:web:e2e`

## 관련 문서 / 이슈

- Closes: #38
- Related:
- Docs: `WORKLOG.md`

## 체크리스트

- [x] 현재 MVP 방향과 충돌하지 않는다
- [x] 기존 문서/구조와 정합성을 확인했다
- [x] 필요한 경우 문서를 함께 수정했다
- [x] 필요한 경우 테스트를 추가했거나 테스트 불필요 사유를 판단했다
- [x] lint / typecheck / test / build 영향을 확인했다

## 비고

- 이번 smoke는 현재 구현에 맞춰 `silent refresh 성공`이 아니라 `세션 정리 후 로그인 재진입` 흐름을 보호합니다.
- `build`는 이번 브랜치에서 다시 실행하지 않았습니다. 변경 범위에 맞춰 web lint/typecheck/e2e 중심으로 검증했습니다.
