### PR TITLE
ci: Playwright smoke artifact 경로 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,14 @@ jobs:
 
       - name: Web smoke e2e test
         run: pnpm test:web:e2e
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-smoke-artifacts
+          path: |
+            apps/web/playwright-report
+            apps/web/test-results
+          if-no-files-found: ignore
+          retention-days: 7

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -38,6 +38,33 @@
 
 ---
 
+## 2026-03-27 (Playwright smoke gate operations)
+
+### 완료
+
+- 이슈 `#41` 기준 Playwright가 `test-results`와 HTML report를 명시적으로 남기도록 설정해 CI 실패 분석 경로를 고정
+- GitHub Actions `ci.yml`에 Playwright artifact 업로드를 추가해 smoke 실패 시 trace, screenshot, report를 바로 확인할 수 있게 정리
+- smoke 시나리오 수를 늘리지 않고 현재 core-loop + auth-expiry 2개 시나리오의 운영 디버깅 가능성을 우선 보강
+
+### 현재 상태
+
+- CI에서 Playwright smoke가 실패해도 report와 test-results를 artifact로 수집해 원인 파악이 쉬워졌다
+- 현재 품질 게이트는 smoke 실행 자체뿐 아니라 실패 분석 자산까지 함께 남기는 구조가 됐다
+- 남은 후속 작업은 실제 GitHub Actions run 기준으로 timeout, retry, artifact 크기를 보며 필요한 범위만 미세 조정하는 쪽이다
+
+### 다음 액션
+
+1. GitHub Actions 실제 run에서 artifact 업로드와 report 내용을 확인해 디버깅 동선이 충분한지 점검한다
+2. smoke 실행 시간이 길어지면 retry 수나 step 분리를 최소 범위로 조정한다
+3. 후속 smoke 시나리오가 늘어나더라도 현재 artifact 구조를 유지할지 별도 job으로 나눌지 판단한다
+
+### 메모
+
+- 검증은 `pnpm --filter @book-maker/web lint`, `typecheck`, `pnpm test:web:e2e` 기준으로 확인한다
+- artifact 업로드는 실패 전용이 아니라 `always()`로 두어 flaky 분석 시에도 동일한 산출물을 확보한다
+
+---
+
 ## 2026-03-27 (Auth expiry smoke e2e)
 
 ### 완료

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -14,11 +14,15 @@ const webServerCommand = process.env.CI
 
 export default defineConfig({
   testDir: './e2e',
+  outputDir: './test-results',
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: 'list',
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: './playwright-report' }],
+  ],
   use: {
     baseURL: webBaseUrl,
     trace: 'on-first-retry',


### PR DESCRIPTION
## 요약

Playwright smoke를 단순 실행 단계가 아니라 실제 운영 가능한 품질 게이트로 다듬었습니다. CI에서 smoke가 실패하더라도 report와 test-results를 artifact로 바로 수집할 수 있게 해, core-loop와 auth-expiry 시나리오의 flaky 원인 분석 경로를 고정했습니다.

## 변경 내용

- Playwright가 `test-results`와 HTML report를 명시적으로 남기도록 output/reporter 설정 추가
- GitHub Actions `ci.yml`에 `always()` 조건의 Playwright artifact 업로드를 추가해 report와 test-results를 CI에서 수집
- smoke 시나리오를 늘리지 않고 현재 core-loop + auth-expiry 2개 시나리오의 운영 디버깅 가능성을 우선 보강
- `WORKLOG.md`에 운영 게이트 정리 작업과 후속 관찰 포인트 기록

## 왜 이 변경이 필요한가

- 현재 단계의 우선순위는 새 기능 확장보다 이미 추가된 Playwright smoke를 실제 PR 품질 게이트로 신뢰 가능하게 만드는 것입니다.
- smoke가 실패했을 때 trace/report/test-results를 바로 확보하지 못하면 flaky 분석과 회귀 대응 속도가 크게 떨어집니다.
- 이번 변경으로 `#35`, `#38`에서 추가된 시나리오를 GitHub Actions에서도 디버깅 가능한 구조로 운영할 수 있게 됩니다.

## 확인 방법

- `pnpm --filter @book-maker/web lint`
- `pnpm --filter @book-maker/web typecheck`
- `pnpm test:web:e2e`

## 관련 문서 / 이슈

- Closes: #41
- Related:
- Docs: `WORKLOG.md`

## 체크리스트

- [x] 현재 MVP 방향과 충돌하지 않는다
- [x] 기존 문서/구조와 정합성을 확인했다
- [x] 필요한 경우 문서를 함께 수정했다
- [x] 필요한 경우 테스트를 추가했거나 테스트 불필요 사유를 판단했다
- [x] lint / typecheck / test / build 영향을 확인했다

## 비고

- 이번 브랜치에서는 GitHub Actions 상의 실제 artifact 업로드 run까지는 확인하지 않았고, 로컬에서 report와 test-results 생성까지 검증했습니다.
- `build`는 이번 브랜치에서 다시 실행하지 않았습니다. 변경 범위에 맞춰 web lint/typecheck/e2e 중심으로 확인했습니다.
