### PR TITLE
feat: 아카이브 기본 검색 흐름 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - MVP 핵심 루프 `write -> archive -> draft -> preview` 구현 완료
 - 랜딩 페이지와 실제 앱 진입 CTA 연결 완료
 - Playwright smoke E2E와 auth-expiry smoke, CI artifact 수집 경로까지 반영
-- 다음 기본 작업 범위는 `Phase 2. Writing Depth And Archive Intelligence`
+- 아카이브 기본 검색 흐름으로 `Phase 2. Writing Depth And Archive Intelligence` 작업 시작
 
 ## 현재 방향
 
@@ -88,8 +88,8 @@
 MVP는 기능 기준으로 닫힌 상태다. 다음 작업은 아래 순서를 기본으로 잡는다.
 
 1. MVP closeout 기준과 문서를 유지
-2. non-blocking polish는 작은 범위로만 정리
-3. `Phase 2. Writing Depth And Archive Intelligence` 범위 이슈를 순차적으로 진행
+2. `Phase 2. Writing Depth And Archive Intelligence` 범위를 작은 단위로 순차 구현
+3. non-blocking polish는 회귀나 명확한 사용성 공백이 있을 때만 다룬다
 
 세부 기준은 [IMPLEMENTATION_PHASES.md](docs/engineering/IMPLEMENTATION_PHASES.md), [MVP_SCOPE.md](docs/product/MVP_SCOPE.md), [ROADMAP.md](docs/product/ROADMAP.md)를 따른다.
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -10,6 +10,35 @@
 
 ---
 
+## 2026-04-04 (Phase 2 archive basic search baseline)
+
+### 완료
+
+- 이슈 `#45` 기준 아카이브 기본 검색 흐름을 추가해 제목/본문 기준 사용자 범위 검색을 시작
+- `GET /entries`에 기본 검색 파라미터를 연결하고 PostgreSQL `ILIKE` 기반 필터를 사용자 소유 범위 안에서 적용
+- 아카이브 화면에 검색 입력, 검색 결과 상태, 전체 보기 복귀 흐름을 추가
+- entries API e2e, entries service 테스트, archive composable 테스트를 보강
+- `README.md`, `docs/product/ROADMAP.md`에 Phase 2 시작 상태를 현재 구현 기준으로 반영
+
+### 현재 상태
+
+- MVP 핵심 루프는 유지한 채 Phase 2의 첫 archive intelligence 기능이 실제 코드에 들어왔다
+- 사용자는 날짜순 아카이브를 그대로 유지하면서 필요한 제목이나 문장을 다시 찾을 수 있다
+- 검색은 별도 검색 엔진 없이 현재 PostgreSQL 쿼리 계층에서 시작하는 baseline 상태다
+
+### 다음 액션
+
+1. 검색 사용성을 보며 tag, filter, reflection view 같은 후속 archive intelligence 작업을 별도 이슈로 나눈다
+2. 검색이 실제 사용 흐름에서 충분하면 route query 유지나 search UX polish 필요 여부를 작은 범위로 판단한다
+3. Phase 2 기능이 늘어날수록 기존 core-loop smoke와 API 권한 테스트로 회귀를 계속 막는다
+
+### 메모
+
+- 이번 작업은 로드맵 후반 기능으로 확장하지 않고 `simple search`만 최소 범위로 도입했다
+- body/title substring 검색은 현재 문서에 맞춰 PostgreSQL `ILIKE`로 시작하고, 더 깊은 검색은 후속 단계에서 판단한다
+
+---
+
 ## 2026-03-27 (MVP closeout and Phase 2 entry)
 
 ### 완료

--- a/apps/api/src/entries/entries.controller.ts
+++ b/apps/api/src/entries/entries.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 
@@ -23,27 +24,21 @@ export class EntriesController {
   constructor(private readonly entriesService: EntriesService) {}
 
   @Post()
-  async createEntry(
-    @CurrentUser() user: AuthenticatedUser,
-    @Body() dto: CreateEntryDto,
-  ) {
+  async createEntry(@CurrentUser() user: AuthenticatedUser, @Body() dto: CreateEntryDto) {
     const entry = await this.entriesService.createEntry(user.userId, dto);
 
     return toPublicEntry(entry);
   }
 
   @Get()
-  async listEntries(@CurrentUser() user: AuthenticatedUser) {
-    const entries = await this.entriesService.listEntries(user.userId);
+  async listEntries(@CurrentUser() user: AuthenticatedUser, @Query('query') query?: string) {
+    const entries = await this.entriesService.listEntries(user.userId, query);
 
     return entries.map(toPublicEntry);
   }
 
   @Get(':entryId')
-  async getEntry(
-    @CurrentUser() user: AuthenticatedUser,
-    @Param('entryId') entryId: string,
-  ) {
+  async getEntry(@CurrentUser() user: AuthenticatedUser, @Param('entryId') entryId: string) {
     const entry = await this.entriesService.findEntryById(user.userId, entryId);
 
     return toPublicEntry(entry);
@@ -61,10 +56,7 @@ export class EntriesController {
   }
 
   @Delete(':entryId')
-  async deleteEntry(
-    @CurrentUser() user: AuthenticatedUser,
-    @Param('entryId') entryId: string,
-  ) {
+  async deleteEntry(@CurrentUser() user: AuthenticatedUser, @Param('entryId') entryId: string) {
     await this.entriesService.deleteEntry(user.userId, entryId);
 
     return {

--- a/apps/api/src/entries/entries.service.spec.ts
+++ b/apps/api/src/entries/entries.service.spec.ts
@@ -46,4 +46,17 @@ describe('EntriesService', () => {
       NotFoundException,
     );
   });
+
+  it('filters entries by a normalized search query inside the current user scope', async () => {
+    query.mockResolvedValue({
+      rows: [],
+    });
+
+    await entriesService.listEntries('user-1', '  파도_기억%  ');
+
+    expect(query).toHaveBeenCalledWith(expect.stringContaining("COALESCE(title, '') ILIKE $2"), [
+      'user-1',
+      '%파도\\_기억\\%%',
+    ]);
+  });
 });

--- a/apps/api/src/entries/entries.service.ts
+++ b/apps/api/src/entries/entries.service.ts
@@ -1,8 +1,4 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 
 import { DatabaseService } from '../infrastructure/database/database.service';
 import { EntryRecord, EntryStatus } from './entry.types';
@@ -49,18 +45,15 @@ export class EntriesService {
           updated_at AS "updatedAt",
           last_saved_at AS "lastSavedAt"
       `,
-      [
-        userId,
-        normalizeTitle(input.title),
-        input.body ?? '',
-        input.status ?? 'draft',
-      ],
+      [userId, normalizeTitle(input.title), input.body ?? '', input.status ?? 'draft'],
     );
 
     return result.rows[0];
   }
 
-  async listEntries(userId: string): Promise<EntryRecord[]> {
+  async listEntries(userId: string, query?: string): Promise<EntryRecord[]> {
+    const normalizedQuery = normalizeSearchQuery(query);
+    const searchPattern = normalizedQuery ? `%${escapeLike(normalizedQuery)}%` : null;
     const result = await this.databaseService.getPool().query<EntryRow>(
       `
         SELECT
@@ -74,9 +67,14 @@ export class EntriesService {
           last_saved_at AS "lastSavedAt"
         FROM entries
         WHERE user_id = $1
+          AND (
+            $2::text IS NULL
+            OR COALESCE(title, '') ILIKE $2 ESCAPE '\\'
+            OR body ILIKE $2 ESCAPE '\\'
+          )
         ORDER BY updated_at DESC, created_at DESC
       `,
-      [userId],
+      [userId, searchPattern],
     );
 
     return result.rows;
@@ -115,11 +113,7 @@ export class EntriesService {
     entryId: string,
     input: UpdateEntryInput,
   ): Promise<EntryRecord> {
-    if (
-      input.title === undefined &&
-      input.body === undefined &&
-      input.status === undefined
-    ) {
+    if (input.title === undefined && input.body === undefined && input.status === undefined) {
       throw new BadRequestException('수정할 기록 필드가 필요합니다.');
     }
 
@@ -187,4 +181,18 @@ function normalizeTitle(title: string | undefined): string | null {
   const normalized = title.trim();
 
   return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeSearchQuery(query: string | undefined): string | null {
+  if (query === undefined) {
+    return null;
+  }
+
+  const normalized = query.trim();
+
+  return normalized.length > 0 ? normalized : null;
+}
+
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, '\\$&');
 }

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -1,12 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import {
-  Controller,
-  Get,
-  INestApplication,
-  Module,
-  Query,
-} from '@nestjs/common';
+import { Controller, Get, INestApplication, Module, Query } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import request from 'supertest';
@@ -187,7 +181,9 @@ class FakePool {
     }
 
     if (
-      normalizedQuery.includes('FROM entries WHERE user_id = $1 ORDER BY updated_at DESC')
+      normalizedQuery.includes('FROM entries') &&
+      normalizedQuery.includes('WHERE user_id = $1') &&
+      normalizedQuery.includes('ORDER BY updated_at DESC, created_at DESC')
     ) {
       return this.listEntries<T>(values);
     }
@@ -213,9 +209,7 @@ class FakePool {
       return this.listDraftEntries<T>(values);
     }
 
-    if (
-      normalizedQuery.includes('FROM entries WHERE user_id = $1 AND id = ANY($2::uuid[])')
-    ) {
+    if (normalizedQuery.includes('FROM entries WHERE user_id = $1 AND id = ANY($2::uuid[])')) {
       return this.selectEntriesByIds<T>(values);
     }
 
@@ -247,17 +241,11 @@ class FakePool {
       return this.updateEntry<T>(values);
     }
 
-    if (
-      normalizedQuery.startsWith('UPDATE drafts') &&
-      normalizedQuery.includes('RETURNING')
-    ) {
+    if (normalizedQuery.startsWith('UPDATE drafts') && normalizedQuery.includes('RETURNING')) {
       return this.updateDraft<T>(values);
     }
 
-    if (
-      normalizedQuery.startsWith('UPDATE drafts') &&
-      !normalizedQuery.includes('RETURNING')
-    ) {
+    if (normalizedQuery.startsWith('UPDATE drafts') && !normalizedQuery.includes('RETURNING')) {
       return this.touchDraft(values);
     }
 
@@ -367,8 +355,22 @@ class FakePool {
 
   private listEntries<T>(values: unknown[]) {
     const userId = values[0] as string;
+    const searchPattern = (values[1] as string | null | undefined) ?? null;
+    const normalizedSearch = normalizeSearchPattern(searchPattern);
     const entries = [...this.entriesById.values()]
-      .filter((entry) => entry.userId === userId)
+      .filter((entry) => {
+        if (entry.userId !== userId) {
+          return false;
+        }
+
+        if (!normalizedSearch) {
+          return true;
+        }
+
+        return (
+          entry.title?.includes(normalizedSearch) === true || entry.body.includes(normalizedSearch)
+        );
+      })
       .sort((left, right) => right.updatedAt.getTime() - left.updatedAt.getTime())
       .map((entry) => this.toEntryRow(entry)) as T[];
 
@@ -692,6 +694,14 @@ class FakePool {
   }
 }
 
+function normalizeSearchPattern(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  return value.replace(/^%|%$/g, '').replace(/\\([\\%_])/g, '$1');
+}
+
 class FakeDatabaseService {
   private readonly pool = new FakePool();
 
@@ -790,14 +800,17 @@ describe('AppController (e2e)', () => {
   it('/api/health (GET)', () => {
     const server = app.getHttpServer();
 
-    return request(server).get('/api/health').expect(200).expect({
-      status: 'ok',
-      service: 'book-maker-api',
-      dependencies: {
-        postgres: 'disabled',
-        redis: 'disabled',
-      },
-    });
+    return request(server)
+      .get('/api/health')
+      .expect(200)
+      .expect({
+        status: 'ok',
+        service: 'book-maker-api',
+        dependencies: {
+          postgres: 'disabled',
+          redis: 'disabled',
+        },
+      });
   });
 
   it('rejects unknown query fields with the global ValidationPipe', () => {
@@ -1002,6 +1015,58 @@ describe('AppController (e2e)', () => {
       .delete(`/api/entries/${createdEntry.id}`)
       .set('Authorization', `Bearer ${stranger.accessToken}`)
       .expect(404);
+  });
+
+  it('filters the archive list by title or body within the current user scope', async () => {
+    const server = app.getHttpServer();
+    const owner = await signup(server, 'search-owner@example.com');
+    const stranger = await signup(server, 'search-other@example.com');
+
+    await createEntry(server, owner.accessToken, {
+      title: '파도 냄새',
+      body: '창문 틈으로 바다 냄새가 스며들었다.',
+    });
+    const matchingEntry = await createEntry(server, owner.accessToken, {
+      title: '저녁 산책',
+      body: '해변에서 주운 문장을 다시 적어 두었다.',
+    });
+    await createEntry(server, owner.accessToken, {
+      title: '산책 메모',
+      body: '도심 골목의 불빛만 남았다.',
+    });
+    await createEntry(server, stranger.accessToken, {
+      title: '해변에서',
+      body: '다른 사용자의 기록은 검색 결과에 보이면 안 된다.',
+    });
+
+    const titleSearchResponse = await request(server)
+      .get('/api/entries')
+      .query({ query: '파도' })
+      .set('Authorization', `Bearer ${owner.accessToken}`)
+      .expect(200);
+    const titleSearchBody = titleSearchResponse.body as EntryResponseBody[];
+
+    expect(titleSearchBody).toHaveLength(1);
+    expect(titleSearchBody[0]?.title).toBe('파도 냄새');
+
+    const bodySearchResponse = await request(server)
+      .get('/api/entries')
+      .query({ query: '주운 문장' })
+      .set('Authorization', `Bearer ${owner.accessToken}`)
+      .expect(200);
+    const bodySearchBody = bodySearchResponse.body as EntryResponseBody[];
+
+    expect(bodySearchBody).toHaveLength(1);
+    expect(bodySearchBody[0]?.id).toBe(matchingEntry.id);
+
+    await request(server)
+      .get('/api/entries')
+      .query({ query: '   ' })
+      .set('Authorization', `Bearer ${owner.accessToken}`)
+      .expect(200)
+      .expect((response) => {
+        expect(response.body).toHaveLength(3);
+      });
   });
 
   it('creates, lists, reads, updates, and adds entries to a draft inside the current user scope', async () => {

--- a/apps/web/app/assets/css/main.css
+++ b/apps/web/app/assets/css/main.css
@@ -720,6 +720,36 @@ textarea {
   flex-direction: column;
 }
 
+.archive-search-form {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.archive-search-field {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.archive-search-label {
+  font-size: 12px;
+  color: var(--text-faint);
+}
+
+.archive-search-field input {
+  height: 48px;
+  padding: 0 16px;
+  border: 1px solid var(--line-strong);
+  background: rgba(255, 253, 250, 0.9);
+}
+
+.archive-search-field input::placeholder {
+  color: var(--text-faint);
+}
+
 .archive-month {
   padding-bottom: 12px;
   margin-top: 40px;
@@ -829,6 +859,10 @@ textarea {
   background: rgba(31, 46, 69, 0.06);
   color: var(--accent);
   font-size: 13px;
+}
+
+.archive-banner strong {
+  font-weight: 700;
 }
 
 .entry-detail-meta {

--- a/apps/web/app/composables/useEntriesArchive.spec.ts
+++ b/apps/web/app/composables/useEntriesArchive.spec.ts
@@ -1,9 +1,4 @@
-import {
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { PublicEntry } from '../types/entries';
 import { useEntriesArchive } from './useEntriesArchive';
@@ -23,12 +18,15 @@ function createEntryFixture(overrides: Partial<PublicEntry> = {}): PublicEntry {
 
 describe('useEntriesArchive', () => {
   it('loads archive entries and marks the list as loaded', async () => {
+    const listEntries = vi
+      .fn()
+      .mockResolvedValue([
+        createEntryFixture(),
+        createEntryFixture({ id: 'entry-2', title: '두 번째 기록' }),
+      ]);
     const archive = useEntriesArchive({
       api: {
-        listEntries: vi.fn().mockResolvedValue([
-          createEntryFixture(),
-          createEntryFixture({ id: 'entry-2', title: '두 번째 기록' }),
-        ]),
+        listEntries,
         getEntry: vi.fn(),
       },
     });
@@ -37,6 +35,7 @@ describe('useEntriesArchive', () => {
 
     expect(archive.listState.value).toBe('loaded');
     expect(archive.entries.value).toHaveLength(2);
+    expect(listEntries).toHaveBeenCalledWith(undefined);
   });
 
   it('marks the archive as empty when there are no entries', async () => {
@@ -74,5 +73,23 @@ describe('useEntriesArchive', () => {
 
     expect(archive.detailState.value).toBe('error');
     expect(archive.detailError.value).toContain('불러오지 못했습니다');
+  });
+
+  it('normalizes the active query and requests filtered entries', async () => {
+    const listEntries = vi
+      .fn()
+      .mockResolvedValue([createEntryFixture({ id: 'entry-9', title: '파도 냄새' })]);
+    const archive = useEntriesArchive({
+      api: {
+        listEntries,
+        getEntry: vi.fn(),
+      },
+    });
+
+    await archive.loadEntries('  파도  ');
+
+    expect(archive.activeQuery.value).toBe('파도');
+    expect(listEntries).toHaveBeenCalledWith('파도');
+    expect(archive.entries.value).toHaveLength(1);
   });
 });

--- a/apps/web/app/composables/useEntriesArchive.ts
+++ b/apps/web/app/composables/useEntriesArchive.ts
@@ -6,7 +6,7 @@ export type ArchiveListState = 'idle' | 'loading' | 'loaded' | 'empty' | 'error'
 export type EntryDetailState = 'idle' | 'loading' | 'loaded' | 'error';
 
 type EntriesReaderApi = {
-  listEntries(): Promise<PublicEntry[]>;
+  listEntries(searchQuery?: string): Promise<PublicEntry[]>;
   getEntry(entryId: string): Promise<PublicEntry>;
 };
 
@@ -18,16 +18,20 @@ export function useEntriesArchive(options: UseEntriesArchiveOptions) {
   const entries = ref<PublicEntry[]>([]);
   const listState = ref<ArchiveListState>('idle');
   const listError = ref('');
+  const activeQuery = ref('');
   const currentEntry = ref<PublicEntry | null>(null);
   const detailState = ref<EntryDetailState>('idle');
   const detailError = ref('');
 
-  async function loadEntries() {
+  async function loadEntries(searchQuery = '') {
+    const normalizedQuery = searchQuery.trim();
+
     listState.value = 'loading';
     listError.value = '';
+    activeQuery.value = normalizedQuery;
 
     try {
-      const nextEntries = await options.api.listEntries();
+      const nextEntries = await options.api.listEntries(normalizedQuery || undefined);
       entries.value = nextEntries;
       listState.value = nextEntries.length > 0 ? 'loaded' : 'empty';
     } catch {
@@ -64,17 +68,14 @@ export function useEntriesArchive(options: UseEntriesArchiveOptions) {
       return;
     }
 
-    entries.value = [
-      ...entries.value.slice(0, index),
-      entry,
-      ...entries.value.slice(index + 1),
-    ];
+    entries.value = [...entries.value.slice(0, index), entry, ...entries.value.slice(index + 1)];
   }
 
   return {
     entries,
     listState,
     listError,
+    activeQuery,
     currentEntry,
     detailState,
     detailError,

--- a/apps/web/app/pages/app/archive.vue
+++ b/apps/web/app/pages/app/archive.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 import { useAuthSession } from '../../composables/useAuthSession';
 import { useEntriesArchive } from '../../composables/useEntriesArchive';
@@ -11,32 +11,36 @@ definePageMeta({ layout: 'app' });
 const runtimeConfig = useRuntimeConfig();
 const route = useRoute();
 
-const {
-  hydrated,
-  isAuthenticated,
-  accessToken,
-  user,
-  hydrateFromStorage,
-} = useAuthSession();
+const { hydrated, isAuthenticated, accessToken, user, hydrateFromStorage } = useAuthSession();
 
-const entriesApi = createEntriesApiClient(
-  runtimeConfig.public.apiBase,
-  () => accessToken.value,
-);
+const entriesApi = createEntriesApiClient(runtimeConfig.public.apiBase, () => accessToken.value);
 const archive = useEntriesArchive({
   api: entriesApi,
 });
-const {
-  entries,
-  listError,
-  listState,
-  loadEntries,
-} = archive;
+const { entries, listError, listState, activeQuery, loadEntries } = archive;
+const searchInput = ref('');
 
 const groupedEntries = computed(() => groupEntriesByMonth(entries.value));
 const highlightedEntryId = computed(() =>
   typeof route.query.entryId === 'string' ? route.query.entryId : null,
 );
+const isSearching = computed(() => activeQuery.value.length > 0);
+const archiveSummary = computed(() => {
+  if (listState.value !== 'loaded' && listState.value !== 'empty') {
+    return '개인 기록';
+  }
+
+  return isSearching.value ? `검색 결과 ${entries.value.length}개` : `${entries.value.length}개`;
+});
+
+async function submitSearch() {
+  await loadEntries(searchInput.value);
+}
+
+async function resetSearch() {
+  searchInput.value = '';
+  await loadEntries();
+}
 
 watch(
   [hydrated, isAuthenticated],
@@ -96,15 +100,36 @@ onMounted(() => {
       <div class="page-header">
         <div>
           <h1 class="page-title">아카이브</h1>
-          <p class="page-subtitle">지금까지 쓴 기록을 날짜순으로 다시 펼쳐봅니다.</p>
+          <p class="page-subtitle">
+            지금까지 쓴 기록을 날짜순으로 다시 펼치고, 필요한 문장을 다시 찾아봅니다.
+          </p>
         </div>
         <div class="page-tools">
-          <span class="entry-meta">
-            {{ listState === 'loaded' ? `${entries.length}개` : '개인 기록' }}
-          </span>
+          <span class="entry-meta">{{ archiveSummary }}</span>
           <NuxtLink class="button-primary" to="/app/write">새 기록</NuxtLink>
         </div>
       </div>
+
+      <form
+        v-if="hydrated && isAuthenticated"
+        class="archive-search-form"
+        @submit.prevent="submitSearch"
+      >
+        <label class="archive-search-field" for="archive-search-input">
+          <span class="archive-search-label">기록 찾기</span>
+          <input
+            id="archive-search-input"
+            v-model="searchInput"
+            data-testid="archive-search-input"
+            type="search"
+            placeholder="제목이나 본문에서 다시 찾고 싶은 문장을 입력해 보세요."
+          />
+        </label>
+        <button class="button-primary" type="submit">검색</button>
+        <button v-if="isSearching" class="button-ghost" type="button" @click="resetSearch">
+          전체 보기
+        </button>
+      </form>
 
       <div v-if="!hydrated" class="archive-state-card">
         <p class="archive-state-copy">저장된 세션을 확인하고 있습니다.</p>
@@ -112,7 +137,8 @@ onMounted(() => {
 
       <div v-else-if="!isAuthenticated" class="archive-state-card">
         <p class="archive-state-copy">
-          아카이브를 보려면 먼저 로그인해야 합니다. 현재 단계에서는 기록하기 화면에서 바로 세션을 만들 수 있습니다.
+          아카이브를 보려면 먼저 로그인해야 합니다. 현재 단계에서는 기록하기 화면에서 바로 세션을
+          만들 수 있습니다.
         </p>
         <NuxtLink class="button-primary" to="/app/write">기록하기로 이동</NuxtLink>
       </div>
@@ -123,21 +149,32 @@ onMounted(() => {
 
       <div v-else-if="listState === 'error'" class="archive-state-card">
         <p class="archive-state-copy">{{ listError }}</p>
-        <button class="button-ghost" type="button" @click="loadEntries">
+        <button class="button-ghost" type="button" @click="loadEntries(activeQuery)">
           다시 불러오기
         </button>
       </div>
 
       <div v-else-if="listState === 'empty'" class="archive-state-card">
         <p class="archive-state-copy">
-          아직 쌓인 기록이 없습니다. 첫 기록을 남기면 이곳에서 다시 찾아볼 수 있습니다.
+          {{
+            isSearching
+              ? '검색한 표현과 맞는 기록이 아직 없습니다. 다른 문장이나 제목으로 다시 찾아보세요.'
+              : '아직 쌓인 기록이 없습니다. 첫 기록을 남기면 이곳에서 다시 찾아볼 수 있습니다.'
+          }}
         </p>
-        <NuxtLink class="button-primary" to="/app/write">첫 기록 남기기</NuxtLink>
+        <button v-if="isSearching" class="button-ghost" type="button" @click="resetSearch">
+          전체 기록 보기
+        </button>
+        <NuxtLink v-else class="button-primary" to="/app/write">첫 기록 남기기</NuxtLink>
       </div>
 
       <div v-else class="archive-list">
         <p v-if="highlightedEntryId" class="archive-banner">
           방금 저장한 기록이 아카이브에 반영되었습니다.
+        </p>
+        <p v-if="isSearching" class="archive-banner" data-testid="archive-search-banner">
+          <strong>{{ activeQuery }}</strong>
+          에 대한 검색 결과입니다.
         </p>
 
         <div v-for="group in groupedEntries" :key="group.key">
@@ -164,7 +201,9 @@ onMounted(() => {
       </div>
 
       <div v-if="listState === 'loaded'" class="archive-folio">
-        <span>{{ entries.length }}개의 기록</span>
+        <span>
+          {{ isSearching ? `${entries.length}개의 검색 결과` : `${entries.length}개의 기록` }}
+        </span>
       </div>
     </section>
   </main>

--- a/apps/web/app/utils/api.ts
+++ b/apps/web/app/utils/api.ts
@@ -18,13 +18,7 @@ type SignupInput = AuthCredentials & {
 
 type Fetcher = (input: string, init?: RequestInit) => Promise<Response>;
 
-type JsonBody =
-  | Record<string, unknown>
-  | string
-  | number
-  | boolean
-  | null
-  | undefined;
+type JsonBody = Record<string, unknown> | string | number | boolean | null | undefined;
 
 export class ApiError extends Error {
   constructor(
@@ -66,10 +60,15 @@ export function createEntriesApiClient(
   fetcher: Fetcher = globalThis.fetch,
 ) {
   return {
-    listEntries() {
-      return requestJson<PublicEntry[]>(fetcher, baseUrl, '/entries', {
-        headers: createAuthHeaders(getAccessToken),
-      });
+    listEntries(searchQuery?: string) {
+      return requestJson<PublicEntry[]>(
+        fetcher,
+        baseUrl,
+        withQuery('/entries', searchQuery ? { query: searchQuery } : undefined),
+        {
+          headers: createAuthHeaders(getAccessToken),
+        },
+      );
     },
     createEntry(input: EntryInput) {
       return requestJson<PublicEntry>(fetcher, baseUrl, '/entries', {
@@ -122,16 +121,11 @@ export function createDraftsApiClient(
       });
     },
     addEntriesToDraft(draftId: string, entryIds: string[]) {
-      return requestJson<PublicDraftDetail>(
-        fetcher,
-        baseUrl,
-        `/drafts/${draftId}/entries`,
-        {
-          method: 'POST',
-          body: { entryIds },
-          headers: createAuthHeaders(getAccessToken),
-        },
-      );
+      return requestJson<PublicDraftDetail>(fetcher, baseUrl, `/drafts/${draftId}/entries`, {
+        method: 'POST',
+        body: { entryIds },
+        headers: createAuthHeaders(getAccessToken),
+      });
     },
     removeDraftEntry(draftId: string, entryId: string) {
       return requestJson<PublicDraftDetail>(
@@ -197,6 +191,24 @@ async function requestJson<T>(
 
 function buildApiUrl(baseUrl: string, path: string): string {
   return `${baseUrl.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`;
+}
+
+function withQuery(path: string, params?: Record<string, string | undefined>): string {
+  if (!params) {
+    return path;
+  }
+
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value) {
+      searchParams.set(key, value);
+    }
+  }
+
+  const query = searchParams.toString();
+
+  return query.length > 0 ? `${path}?${query}` : path;
 }
 
 async function readPayload(response: Response): Promise<unknown> {

--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -254,8 +254,9 @@ It evolves in layers:
 
 Current confirmed focus:
 
-- Phase 1 only
+- Phase 1 complete
+- Phase 2 started with archive basic search baseline
 
 Documented for future planning:
 
-- Phase 2 through Phase 7
+- remaining Phase 2 through Phase 7


### PR DESCRIPTION
## 요약

Phase 2의 첫 archive intelligence 작업으로 아카이브 기본 검색 흐름을 추가했습니다. 사용자는 기존 날짜순 아카이브를 유지한 채 제목이나 본문 문장을 기준으로 자신의 기록을 다시 찾을 수 있습니다.

## 변경 내용

- `GET /entries?query=` 계약을 추가하고 사용자 범위 안에서 PostgreSQL `ILIKE` 기반 제목/본문 검색을 연결했습니다.
- 아카이브 화면에 검색 입력, 검색 결과 배너, 0건 빈 상태, 전체 보기 복귀 흐름을 추가했습니다.
- entries service 테스트, API e2e, archive composable 테스트를 보강하고 테스트용 fake query 매처를 새 검색 SQL에 맞게 갱신했습니다.
- `README.md`, `WORKLOG.md`, `docs/product/ROADMAP.md`를 업데이트해 Phase 2가 아카이브 기본 검색부터 시작됐다는 현재 상태를 반영했습니다.

## 왜 이 변경이 필요한가

MVP 핵심 루프는 이미 닫힌 상태라 다음 작업은 `Phase 2. Writing Depth And Archive Intelligence` 범위여야 합니다. 현재 문서 기준으로 아카이브는 단순 저장소가 아니라 과거 기록을 다시 발견하는 공간이어야 하고, 사용자 여정과 IA도 검색 또는 필터 진입점을 요구하고 있습니다. 이번 변경은 태그, 타임라인, 리플렉션 뷰 같은 후속 기능 전에 가장 작은 archive intelligence baseline을 실제 제품에 넣는 작업입니다.

## 확인 방법

- `pnpm lint:web`
- `pnpm typecheck:web`
- `pnpm test:web -- useEntriesArchive.spec.ts`
- `pnpm lint:api`
- `pnpm typecheck:api`
- `pnpm --filter @book-maker/api test -- --runInBand src/entries/entries.service.spec.ts`
- `pnpm test:api:e2e -- --runInBand --testPathPatterns app.e2e-spec.ts`
- `pnpm exec prettier --write README.md WORKLOG.md docs/product/ROADMAP.md apps/api/src/entries/entries.controller.ts apps/api/src/entries/entries.service.ts apps/api/src/entries/entries.service.spec.ts apps/api/test/app.e2e-spec.ts apps/web/app/utils/api.ts apps/web/app/composables/useEntriesArchive.ts apps/web/app/composables/useEntriesArchive.spec.ts apps/web/app/pages/app/archive.vue apps/web/app/assets/css/main.css`

## 관련 문서 / 이슈

- Closes: #45
- Related:
- Docs: `README.md`, `WORKLOG.md`, `docs/product/ROADMAP.md`

## 체크리스트

- [x] 현재 MVP 방향과 충돌하지 않는다
- [x] 기존 문서/구조와 정합성을 확인했다
- [x] 필요한 경우 문서를 함께 수정했다
- [x] 필요한 경우 테스트를 추가했거나 테스트 불필요 사유를 판단했다
- [x] lint / typecheck / test / build 영향을 확인했다

## 비고

- 이번 범위는 `simple search` baseline에 한정했습니다. tags, timeline, reflection view 같은 후속 archive intelligence 작업은 별도 이슈로 분리하는 쪽이 맞습니다.
- 전체 저장소 기준 full build는 이번 변경 직접 영향 범위보다 넓어 실행하지 않았습니다.
